### PR TITLE
feat: add API management page

### DIFF
--- a/app.js
+++ b/app.js
@@ -631,7 +631,11 @@ app.post('/admin/apis/keys', requireDashboardAdmin, requireDashboardCsrf, async 
     return res.status(201).json({
       success: true,
       apiKey: {
-        ...apiKey,
+        id: apiKey.id,
+        name: apiKey.name,
+        key_prefix: apiKey.key_prefix,
+        created_at: apiKey.created_at,
+        last_used_at: apiKey.last_used_at,
         secret: `qs.${id}.${secret}`
       }
     });

--- a/app.js
+++ b/app.js
@@ -31,7 +31,7 @@ const DASHBOARD_ADMIN_COOKIE = 'dashboard_admin_session';
 const ADMIN_TTL_MS = 24 * 60 * 60 * 1000;
 const PAGE_ACCESS_TTL_MS = 24 * 60 * 60 * 1000;
 const VALID_CODE_TYPES = new Set(['html', 'markdown', 'svg', 'mermaid']);
-const timingSafeEqual = require('crypto').timingSafeEqual;
+const { randomBytes, timingSafeEqual } = require('crypto');
 
 const app = express();
 const pageRepository = createPageRepository();
@@ -163,23 +163,70 @@ function requireCsrf(req, res, next) {
   return next();
 }
 
-function requireApiKey(req, res, next) {
-  if (!config.shareApiKey) {
-    return res.status(503).json({ success: false, error: 'API key not configured' });
+function requireDashboardCsrf(req, res, next) {
+  if (!config.authEnabled) {
+    return next();
   }
 
+  const sessionToken = req.dashboardAdminSession?.token || req.cookies?.[DASHBOARD_ADMIN_COOKIE];
+  const csrfToken = req.get('x-csrf-token') || req.body?._csrf;
+
+  if (!verifyCsrfToken(sessionToken, csrfToken)) {
+    return res.status(403).json({
+      success: false,
+      error: 'Invalid CSRF token'
+    });
+  }
+
+  return next();
+}
+
+async function requireApiKey(req, res, next) {
   const key = req.get('x-api-key');
+
   if (!key) {
     return res.status(401).json({ success: false, error: 'Missing X-API-Key header' });
   }
 
-  const expected = Buffer.from(config.shareApiKey);
-  const provided = Buffer.from(key);
-  if (expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+  if (config.shareApiKey) {
+    const expected = Buffer.from(config.shareApiKey);
+    const provided = Buffer.from(key);
+
+    if (expected.length === provided.length && timingSafeEqual(expected, provided)) {
+      return next();
+    }
+  }
+
+  const match = /^qs\.([A-Za-z0-9_-]{1,64})\.([A-Za-z0-9_-]{20,})$/.exec(key);
+
+  if (!match) {
     return res.status(401).json({ success: false, error: 'Invalid API key' });
   }
 
-  return next();
+  try {
+    await ensureDatabase();
+
+    const apiKey = await pageRepository.getApiKeyById(match[1]);
+    const isValid = apiKey && await verifySecret(match[2], apiKey.key_hash);
+
+    if (!isValid) {
+      return res.status(401).json({ success: false, error: 'Invalid API key' });
+    }
+
+    req.managedApiKey = {
+      id: apiKey.id,
+      name: apiKey.name
+    };
+
+    pageRepository.touchApiKey(apiKey.id).catch((error) => {
+      console.error('API key usage update failed:', error);
+    });
+
+    return next();
+  } catch (error) {
+    console.error('API key validation failed:', error);
+    return res.status(503).json({ success: false, error: 'API authentication unavailable' });
+  }
 }
 
 async function verifyAdminPassword(password) {
@@ -525,6 +572,106 @@ app.get('/admin', (req, res) => {
   }
 
   return res.redirect('/admin/login');
+});
+
+app.get('/admin/apis', requireDashboardAdmin, async (req, res) => {
+  try {
+    await ensureDatabase();
+
+    const apiKeys = await pageRepository.listApiKeys();
+    const sessionToken = req.dashboardAdminSession?.token || req.cookies?.[DASHBOARD_ADMIN_COOKIE] || '';
+
+    return res.render('admin-apis', {
+      title: 'QuickShare | API Management',
+      page: 'admin-apis',
+      apiKeys,
+      legacyApiKeyConfigured: Boolean(config.shareApiKey),
+      csrfToken: config.authEnabled ? createCsrfToken(sessionToken) : ''
+    });
+  } catch (error) {
+    console.error('API management page failed:', error);
+    return res.status(500).render('error', {
+      title: 'Server Error',
+      page: 'error-page',
+      message: 'Unable to load API management'
+    });
+  }
+});
+
+app.post('/admin/apis/keys', requireDashboardAdmin, requireDashboardCsrf, async (req, res) => {
+  try {
+    await ensureDatabase();
+
+    const name = String(req.body?.name || '').trim();
+
+    if (!name || name.length > 80) {
+      return res.status(400).json({
+        success: false,
+        error: 'Key name must be between 1 and 80 characters'
+      });
+    }
+
+    const id = generateId(12);
+    const secret = randomBytes(32).toString('base64url');
+    const apiKey = await pageRepository.createApiKey({
+      id,
+      name,
+      keyHash: await hashSecret(secret),
+      keyPrefix: `qs.${id.slice(0, 8)}…`,
+      createdAt: Date.now()
+    });
+
+    pageRepository.createAuditLog({
+      action: 'api_key.create',
+      pageId: null,
+      details: JSON.stringify({ apiKeyId: apiKey.id, name: apiKey.name }),
+      ip: req.ip || req.headers['x-forwarded-for'] || req.connection.remoteAddress
+    }).catch((err) => { console.error('Audit log failed:', err); });
+
+    return res.status(201).json({
+      success: true,
+      apiKey: {
+        ...apiKey,
+        secret: `qs.${id}.${secret}`
+      }
+    });
+  } catch (error) {
+    console.error('Create API key failed:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to create API key'
+    });
+  }
+});
+
+app.delete('/admin/apis/keys/:id', requireDashboardAdmin, requireDashboardCsrf, async (req, res) => {
+  try {
+    await ensureDatabase();
+
+    const deleted = await pageRepository.deleteApiKey(req.params.id);
+
+    if (!deleted) {
+      return res.status(404).json({
+        success: false,
+        error: 'API key not found'
+      });
+    }
+
+    pageRepository.createAuditLog({
+      action: 'api_key.delete',
+      pageId: null,
+      details: JSON.stringify({ apiKeyId: req.params.id }),
+      ip: req.ip || req.headers['x-forwarded-for'] || req.connection.remoteAddress
+    }).catch((err) => { console.error('Audit log failed:', err); });
+
+    return res.json({ success: true });
+  } catch (error) {
+    console.error('Delete API key failed:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to delete API key'
+    });
+  }
 });
 
 app.get('/admin/pages/export', requireDashboardAdmin, async (req, res) => {

--- a/models/memory-pages.js
+++ b/models/memory-pages.js
@@ -33,6 +33,7 @@ class MemoryPageRepository {
     this.pages = new Map();
     this.auditLogs = [];
     this.auditIdCounter = 0;
+    this.apiKeys = new Map();
   }
 
   async init() {
@@ -62,6 +63,48 @@ class MemoryPageRepository {
     });
 
     return { id: page.id };
+  }
+
+  async createApiKey(apiKey) {
+    if (this.apiKeys.has(apiKey.id)) {
+      const error = new Error('UNIQUE constraint failed: api_keys.id');
+      error.code = 'SQLITE_CONSTRAINT';
+      throw error;
+    }
+
+    const record = {
+      id: apiKey.id,
+      name: apiKey.name,
+      key_hash: apiKey.keyHash,
+      key_prefix: apiKey.keyPrefix,
+      created_at: apiKey.createdAt,
+      last_used_at: null
+    };
+
+    this.apiKeys.set(record.id, record);
+    return { ...record };
+  }
+
+  async listApiKeys() {
+    return Array.from(this.apiKeys.values())
+      .sort((left, right) => Number(right.created_at) - Number(left.created_at))
+      .map(({ key_hash, ...apiKey }) => ({ ...apiKey }));
+  }
+
+  async getApiKeyById(id) {
+    return this.apiKeys.get(id) || null;
+  }
+
+  async deleteApiKey(id) {
+    return this.apiKeys.delete(id);
+  }
+
+  async touchApiKey(id, usedAt = Date.now()) {
+    const apiKey = this.apiKeys.get(id);
+
+    if (apiKey) {
+      apiKey.last_used_at = usedAt;
+    }
   }
 
   async getById(id) {

--- a/models/memory-pages.js
+++ b/models/memory-pages.js
@@ -82,7 +82,13 @@ class MemoryPageRepository {
     };
 
     this.apiKeys.set(record.id, record);
-    return { ...record };
+    return {
+      id: record.id,
+      name: record.name,
+      key_prefix: record.key_prefix,
+      created_at: record.created_at,
+      last_used_at: record.last_used_at
+    };
   }
 
   async listApiKeys() {

--- a/models/postgres-pages.js
+++ b/models/postgres-pages.js
@@ -79,6 +79,18 @@ class PostgresPageRepository {
     `);
     await this.pool.query('CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at DESC)');
     await this.pool.query('CREATE INDEX IF NOT EXISTS idx_audit_logs_page_id ON audit_logs (page_id)');
+
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS api_keys (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        key_hash TEXT NOT NULL,
+        key_prefix TEXT NOT NULL,
+        created_at BIGINT NOT NULL,
+        last_used_at BIGINT
+      )
+    `);
+    await this.pool.query('CREATE INDEX IF NOT EXISTS idx_api_keys_created_at ON api_keys (created_at DESC)');
   }
 
   async create(page) {
@@ -382,6 +394,49 @@ class PostgresPageRepository {
     if (!Array.isArray(ids) || ids.length === 0) return 0;
     const result = await this.pool.query('DELETE FROM pages WHERE id = ANY($1)', [ids]);
     return result.rowCount;
+  }
+
+  async createApiKey(apiKey) {
+    const result = await this.pool.query(
+      `
+        INSERT INTO api_keys (id, name, key_hash, key_prefix, created_at)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, name, key_prefix, created_at, last_used_at
+      `,
+      [apiKey.id, apiKey.name, apiKey.keyHash, apiKey.keyPrefix, apiKey.createdAt]
+    );
+
+    return result.rows[0];
+  }
+
+  async listApiKeys() {
+    const result = await this.pool.query(
+      `
+        SELECT id, name, key_prefix, created_at, last_used_at
+        FROM api_keys
+        ORDER BY created_at DESC
+      `
+    );
+
+    return result.rows;
+  }
+
+  async getApiKeyById(id) {
+    const result = await this.pool.query(
+      'SELECT id, name, key_hash, key_prefix, created_at, last_used_at FROM api_keys WHERE id = $1 LIMIT 1',
+      [id]
+    );
+
+    return result.rows[0] || null;
+  }
+
+  async deleteApiKey(id) {
+    const result = await this.pool.query('DELETE FROM api_keys WHERE id = $1', [id]);
+    return result.rowCount > 0;
+  }
+
+  async touchApiKey(id, usedAt = Date.now()) {
+    await this.pool.query('UPDATE api_keys SET last_used_at = $2 WHERE id = $1', [id, usedAt]);
   }
 
   async createAuditLog({ action, pageId, details, ip }) {

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3602,3 +3602,161 @@ body:hover::-webkit-scrollbar,
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.15);
 }
+
+/* ===== API management ===== */
+.api-key-create {
+  gap: 1rem;
+}
+
+.api-key-form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.api-key-form label {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.api-key-form-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.api-key-form-row .cyber-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.api-key-secret-panel {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(var(--primary-rgb), 0.45);
+  border-radius: 10px;
+  background: rgba(var(--primary-rgb), 0.08);
+}
+
+.api-key-secret-panel p,
+.api-legacy-notice p {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.api-key-secret-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.api-key-secret-row code {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+}
+
+.api-legacy-notice {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.api-legacy-notice > i {
+  color: var(--primary);
+  margin-top: 0.25rem;
+}
+
+.api-key-prefix {
+  color: var(--text-secondary);
+}
+
+.api-key-empty {
+  padding: 2rem !important;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.api-docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.api-doc-card {
+  gap: 1rem;
+}
+
+.api-doc-card h2,
+.api-doc-card h3 {
+  font-size: 1rem;
+}
+
+.api-doc-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.95rem;
+}
+
+.api-method {
+  padding: 0.25rem 0.45rem;
+  border-radius: 5px;
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.api-doc-card > p,
+.api-field-list dd {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.api-doc-card pre {
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-family: 'Fira Code', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.api-field-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.api-field-list > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.api-field-list dt {
+  font-weight: 600;
+}
+
+.api-field-list dt span {
+  color: #f59e0b;
+  font-size: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .api-docs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .api-key-form-row,
+  .api-key-secret-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/public/js/admin-apis.js
+++ b/public/js/admin-apis.js
@@ -1,0 +1,188 @@
+(function () {
+  const form = document.getElementById('api-key-form');
+  const nameInput = document.getElementById('api-key-name');
+  const secretPanel = document.getElementById('new-api-key-panel');
+  const secretValue = document.getElementById('new-api-key-value');
+  const copyButton = document.getElementById('copy-api-key-btn');
+  const keyRows = document.getElementById('api-keys-body');
+
+  if (!form || !keyRows) return;
+
+  function csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content || '';
+  }
+
+  function notify(type, message) {
+    if (window.Toast && typeof window.Toast[type] === 'function') {
+      window.Toast[type](message);
+      return;
+    }
+
+    window.alert(message);
+  }
+
+  function formatTime(value) {
+    return new Date(Number(value)).toLocaleString('zh-CN', { hour12: false });
+  }
+
+  function removeEmptyState() {
+    document.getElementById('api-keys-empty')?.remove();
+  }
+
+  function addEmptyState() {
+    if (keyRows.children.length > 0) return;
+
+    const row = document.createElement('tr');
+    row.id = 'api-keys-empty';
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.className = 'api-key-empty';
+    cell.textContent = 'No managed keys yet.';
+    row.appendChild(cell);
+    keyRows.appendChild(row);
+  }
+
+  function createCell(text, className) {
+    const cell = document.createElement('td');
+
+    if (className) cell.className = className;
+    cell.textContent = text;
+    return cell;
+  }
+
+  function addKeyRow(apiKey) {
+    removeEmptyState();
+
+    const row = document.createElement('tr');
+    row.dataset.apiKeyId = apiKey.id;
+
+    const name = document.createElement('td');
+    const strong = document.createElement('strong');
+    strong.textContent = apiKey.name;
+    name.appendChild(strong);
+
+    const prefix = document.createElement('td');
+    const prefixCode = document.createElement('code');
+    prefixCode.className = 'api-key-prefix';
+    prefixCode.textContent = apiKey.key_prefix;
+    prefix.appendChild(prefixCode);
+
+    const created = document.createElement('td');
+    const createdTime = document.createElement('time');
+    createdTime.dateTime = new Date(Number(apiKey.created_at)).toISOString();
+    createdTime.textContent = formatTime(apiKey.created_at);
+    created.appendChild(createdTime);
+
+    const lastUsed = createCell('Never', 'admin-muted');
+
+    const actions = document.createElement('td');
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'admin-delete-btn api-key-delete-btn';
+    remove.dataset.apiKeyId = apiKey.id;
+    remove.dataset.apiKeyName = apiKey.name;
+    remove.textContent = 'Delete';
+    actions.appendChild(remove);
+
+    row.append(name, prefix, created, lastUsed, actions);
+    keyRows.prepend(row);
+  }
+
+  async function deleteKey(button) {
+    const id = button.dataset.apiKeyId;
+    const name = button.dataset.apiKeyName || 'this key';
+
+    if (!id || !window.confirm(`Delete ${name}? Any automation using it will stop working immediately.`)) {
+      return;
+    }
+
+    button.disabled = true;
+
+    try {
+      const response = await fetch('/admin/apis/keys/' + encodeURIComponent(id), {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json',
+          'X-CSRF-Token': csrfToken()
+        }
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to delete API key');
+      }
+
+      button.closest('tr')?.remove();
+      addEmptyState();
+      notify('success', 'API key deleted');
+    } catch (error) {
+      button.disabled = false;
+      notify('error', error.message);
+    }
+  }
+
+  form.addEventListener('submit', async function (event) {
+    event.preventDefault();
+
+    const name = nameInput.value.trim();
+    const submit = form.querySelector('button[type="submit"]');
+
+    if (!name) {
+      nameInput.focus();
+      return;
+    }
+
+    submit.disabled = true;
+
+    try {
+      const response = await fetch('/admin/apis/keys', {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken()
+        },
+        body: JSON.stringify({ name })
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to create API key');
+      }
+
+      secretValue.textContent = data.apiKey.secret;
+      secretPanel.hidden = false;
+      nameInput.value = '';
+      addKeyRow(data.apiKey);
+      notify('success', 'API key created');
+    } catch (error) {
+      notify('error', error.message);
+    } finally {
+      submit.disabled = false;
+    }
+  });
+
+  copyButton?.addEventListener('click', async function () {
+    const secret = secretValue.textContent;
+
+    if (!secret) return;
+
+    try {
+      await navigator.clipboard.writeText(secret);
+      notify('success', 'API key copied');
+    } catch (error) {
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(secretValue);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      notify('info', 'Select and copy the key manually');
+    }
+  });
+
+  keyRows.addEventListener('click', function (event) {
+    const button = event.target.closest('.api-key-delete-btn');
+
+    if (button) deleteKey(button);
+  });
+})();

--- a/test/admin-routes.test.js
+++ b/test/admin-routes.test.js
@@ -224,3 +224,73 @@ test('admin page detail returns 404 for missing pages', async () => {
 
   assert.equal(response.status, 404);
 });
+
+
+test('API management creates, documents, and deletes managed keys', async () => {
+  const cookie = await loginDashboard();
+  const pageResponse = await request('/admin/apis', {
+    headers: { Cookie: cookie }
+  });
+
+  assert.equal(pageResponse.status, 200);
+  assert.match(pageResponse.text, /API Management/);
+  assert.match(pageResponse.text, /POST<\/span>\s*<code>\/api\/v1\/share<\/code>/);
+  assert.doesNotMatch(pageResponse.text, /key_hash/);
+
+  const csrfMatch = pageResponse.text.match(/name="csrf-token" content="([^"]+)"/);
+  assert.ok(csrfMatch);
+
+  const createResponse = await request('/admin/apis/keys', {
+    method: 'POST',
+    headers: {
+      Cookie: cookie,
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfMatch[1]
+    },
+    body: JSON.stringify({ name: 'API management test' })
+  });
+
+  assert.equal(createResponse.status, 201);
+  const created = JSON.parse(createResponse.text).apiKey;
+  assert.match(created.secret, /^qs\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+  assert.equal(created.key_hash, undefined);
+
+  const apiResponse = await request('/api/v1/share', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': created.secret
+    },
+    body: JSON.stringify({ htmlContent: '<h1>Managed route key</h1>' })
+  });
+
+  assert.equal(apiResponse.status, 200);
+
+  const listResponse = await request('/admin/apis', {
+    headers: { Cookie: cookie }
+  });
+  assert.match(listResponse.text, /API management test/);
+  assert.doesNotMatch(listResponse.text, new RegExp(created.secret));
+  assert.doesNotMatch(listResponse.text, /key_hash/);
+
+  const deleteResponse = await request('/admin/apis/keys/' + encodeURIComponent(created.id), {
+    method: 'DELETE',
+    headers: {
+      Cookie: cookie,
+      'X-CSRF-Token': csrfMatch[1]
+    }
+  });
+
+  assert.equal(deleteResponse.status, 200);
+
+  const revokedResponse = await request('/api/v1/share', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': created.secret
+    },
+    body: JSON.stringify({ htmlContent: '<h1>Should not be created</h1>' })
+  });
+
+  assert.equal(revokedResponse.status, 401);
+});

--- a/test/api-v1-share.test.js
+++ b/test/api-v1-share.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('http');
+const { hashSecret } = require('../utils/security');
 
 process.env.NODE_ENV = 'test';
 process.env.AUTH_ENABLED = 'false';
@@ -144,4 +145,28 @@ test('POST /api/v1/share supports password protection', async () => {
   assert.equal(res.body.isProtected, true);
   assert.ok(res.body.password);
   assert.ok(/^\d{6}$/.test(res.body.password));
+});
+
+
+test('POST /api/v1/share accepts a managed API key', async () => {
+  const id = 'managed-api-key-test';
+  const secret = 'managed-api-key-secret-12345';
+
+  await app.locals.pageRepository.createApiKey({
+    id,
+    name: 'Managed API test',
+    keyHash: await hashSecret(secret),
+    keyPrefix: 'qs.managed-…',
+    createdAt: Date.now()
+  });
+
+  const res = await post('/api/v1/share', {
+    htmlContent: '<h1>Managed key</h1>'
+  }, { 'X-API-Key': `qs.${id}.${secret}` });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.success, true);
+
+  const apiKey = await app.locals.pageRepository.getApiKeyById(id);
+  assert.ok(apiKey.last_used_at);
 });

--- a/views/admin-apis.ejs
+++ b/views/admin-apis.ejs
@@ -1,0 +1,155 @@
+<%- include('partials/header', { title, page, csrfToken }) %>
+
+<div class="admin-container">
+  <header class="admin-header">
+    <div>
+      <p class="admin-kicker">QuickShare</p>
+      <h1 class="admin-title">API Management</h1>
+      <p class="admin-subtitle">Manage API access keys and use the code-backed Share API reference.</p>
+    </div>
+    <div class="admin-actions">
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/stats">
+        <i class="fas fa-chart-bar" aria-hidden="true"></i>
+        <span>Stats</span>
+      </a>
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/pages">
+        <i class="fas fa-table" aria-hidden="true"></i>
+        <span>Pages</span>
+      </a>
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/audit">
+        <i class="fas fa-history" aria-hidden="true"></i>
+        <span>Audit</span>
+      </a>
+    </div>
+  </header>
+
+  <section class="card api-key-create">
+    <div class="admin-content-header">
+      <div>
+        <h2>Access Keys</h2>
+        <p class="admin-muted">Create a separate key for every automation. The full secret is shown only once.</p>
+      </div>
+    </div>
+
+    <form id="api-key-form" class="api-key-form">
+      <label for="api-key-name">Key name</label>
+      <div class="api-key-form-row">
+        <input id="api-key-name" name="name" class="cyber-input" maxlength="80" required placeholder="e.g. Namoo QuickShare skill" autocomplete="off">
+        <button class="cyber-btn cyber-btn-primary" type="submit">
+          <i class="fas fa-key" aria-hidden="true"></i>
+          <span>Create key</span>
+        </button>
+      </div>
+    </form>
+
+    <div id="new-api-key-panel" class="api-key-secret-panel" hidden>
+      <div>
+        <strong>Copy this key now</strong>
+        <p>It will not be shown again after you leave this page.</p>
+      </div>
+      <div class="api-key-secret-row">
+        <code id="new-api-key-value"></code>
+        <button id="copy-api-key-btn" class="cyber-btn cyber-btn-secondary" type="button">Copy</button>
+      </div>
+    </div>
+  </section>
+
+  <% if (legacyApiKeyConfigured) { %>
+    <section class="card api-legacy-notice">
+      <i class="fas fa-info-circle" aria-hidden="true"></i>
+      <p><strong>Legacy environment key active.</strong> <code>SHARE_API_KEY</code> continues to work for compatibility, but it cannot be viewed or revoked here.</p>
+    </section>
+  <% } %>
+
+  <section class="card admin-card">
+    <div class="admin-content-header">
+      <div>
+        <h2>Managed Keys</h2>
+        <p class="admin-muted"><%= apiKeys.length %> active key<%= apiKeys.length === 1 ? '' : 's' %></p>
+      </div>
+    </div>
+
+    <div class="admin-table-wrap">
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Prefix</th>
+            <th>Created</th>
+            <th>Last used</th>
+            <th class="admin-actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="api-keys-body">
+          <% if (apiKeys.length === 0) { %>
+            <tr id="api-keys-empty">
+              <td colspan="5" class="api-key-empty">No managed keys yet.</td>
+            </tr>
+          <% } %>
+          <% apiKeys.forEach((apiKey) => { %>
+            <tr data-api-key-id="<%= apiKey.id %>">
+              <td><strong><%= apiKey.name %></strong></td>
+              <td><code class="api-key-prefix"><%= apiKey.key_prefix %></code></td>
+              <td><time datetime="<%= new Date(Number(apiKey.created_at)).toISOString() %>"><%= new Date(Number(apiKey.created_at)).toLocaleString('zh-CN', { hour12: false }) %></time></td>
+              <td>
+                <% if (apiKey.last_used_at) { %>
+                  <time datetime="<%= new Date(Number(apiKey.last_used_at)).toISOString() %>"><%= new Date(Number(apiKey.last_used_at)).toLocaleString('zh-CN', { hour12: false }) %></time>
+                <% } else { %>
+                  <span class="admin-muted">Never</span>
+                <% } %>
+              </td>
+              <td>
+                <button type="button" class="admin-delete-btn api-key-delete-btn" data-api-key-id="<%= apiKey.id %>" data-api-key-name="<%= apiKey.name %>">
+                  <i class="fas fa-trash-alt" aria-hidden="true"></i>
+                  <span>Delete</span>
+                </button>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="api-docs-grid">
+    <article class="card api-doc-card">
+      <div class="api-doc-heading">
+        <span class="api-method">POST</span>
+        <code>/api/v1/share</code>
+      </div>
+      <p>Create a QuickShare page from HTML, Markdown, SVG, or Mermaid content.</p>
+      <h3>Authentication</h3>
+      <p>Send a managed key in the <code>X-API-Key</code> header. The existing <code>SHARE_API_KEY</code> remains supported when configured.</p>
+      <pre><code>curl -s -X POST "$QUICKSHARE_URL/api/v1/share" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $QUICKSHARE_API_KEY" \
+  -d '{
+    "htmlContent": "&lt;h1&gt;Hello&lt;/h1&gt;",
+    "codeType": "html",
+    "title": "Hello"
+  }'</code></pre>
+    </article>
+
+    <article class="card api-doc-card">
+      <h2>Request body</h2>
+      <dl class="api-field-list">
+        <div><dt><code>htmlContent</code> <span>required</span></dt><dd>Content to share.</dd></div>
+        <div><dt><code>codeType</code></dt><dd><code>html</code>, <code>markdown</code>, <code>svg</code>, or <code>mermaid</code>. Auto-detected when omitted.</dd></div>
+        <div><dt><code>title</code> / <code>description</code></dt><dd>Optional page metadata.</dd></div>
+        <div><dt><code>isProtected</code></dt><dd>When true, QuickShare creates a page password and returns it once.</dd></div>
+      </dl>
+      <h2>Response</h2>
+      <pre><code>{
+  "success": true,
+  "urlId": "…",
+  "url": "https://…/view/…",
+  "codeType": "html",
+  "isProtected": false
+}</code></pre>
+    </article>
+  </section>
+</div>
+
+<script src="/js/admin.js"></script>
+<script src="/js/admin-apis.js"></script>
+<%- include('partials/footer', { page }) %>

--- a/views/admin-audit.ejs
+++ b/views/admin-audit.ejs
@@ -12,6 +12,10 @@
         <i class="fas fa-chart-bar" aria-hidden="true"></i>
         <span>Stats</span>
       </a>
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/apis">
+        <i class="fas fa-key" aria-hidden="true"></i>
+        <span>API</span>
+      </a>
       <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/pages">
         <i class="fas fa-table" aria-hidden="true"></i>
         <span>Pages</span>

--- a/views/admin-pages.ejs
+++ b/views/admin-pages.ejs
@@ -12,6 +12,10 @@
         <i class="fas fa-chart-bar" aria-hidden="true"></i>
         <span>Stats</span>
       </a>
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/apis">
+        <i class="fas fa-key" aria-hidden="true"></i>
+        <span>API</span>
+      </a>
       <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/audit">
         <i class="fas fa-history" aria-hidden="true"></i>
         <span>Audit</span>

--- a/views/admin-stats.ejs
+++ b/views/admin-stats.ejs
@@ -12,6 +12,10 @@
         <i class="fas fa-table" aria-hidden="true"></i>
         <span>Pages</span>
       </a>
+      <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/apis">
+        <i class="fas fa-key" aria-hidden="true"></i>
+        <span>API</span>
+      </a>
       <a class="cyber-btn cyber-btn-secondary admin-home-link" href="/admin/audit">
         <i class="fas fa-history" aria-hidden="true"></i>
         <span>Audit</span>


### PR DESCRIPTION
## What changed
- add `/admin/apis` with a code-backed `POST /api/v1/share` reference
- create, list, delete, and audit individually managed API keys
- keep `SHARE_API_KEY` valid for existing callers
- store only scrypt hashes and reveal a new managed key once
- cover the key lifecycle and managed-key API authentication

## Validation
- static JavaScript parse passed for changed server, repository, and test files
- Vercel preview build is successful
- local `npm test` is still blocked by this task's shell executor failing before process creation