### PR TITLE
feat: add Markdown theme catalog

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,46 @@ QuickShare manages published content shares and the management concepts used to 
 A published content item that can be opened through its generated address.
 _Avoid_: Link, page
 
+**Markdown Theme Preset**:
+A named, brand-inspired presentation choice for a Markdown Share. It changes the Share's visual treatment without changing its Markdown content or the QuickShare site shell, and does not claim to replicate an official brand interface.
+_Avoid_: Site theme, brand replica, Markdown template
+
+**Preset Visual Identity**:
+The recognizable combination of typography, color, spacing, and signature rendered elements that distinguishes one Markdown Theme Preset from another. It remains recognizable across Theme Reading Baseline, adaptive appearance, and accessibility improvements without requiring pixel-identical output.
+_Avoid_: Pixel snapshot, brand replica, immutable stylesheet
+
+**Markdown Theme Catalog**:
+The curated set of Markdown Theme Presets built into QuickShare and available to Share creators and administrators. Presets enter the Catalog through a QuickShare release rather than user-authored settings or CSS.
+_Avoid_: Theme editor, custom CSS library, theme marketplace
+
+**Preset Label**:
+The user-facing Catalog name that combines a Markdown Theme Preset's brand inspiration with QuickShare's description of its visual direction. A Preset Label may change without changing the Preset's stable stored identifier.
+_Avoid_: Official theme name, preset identifier, brand name alone
+
+**Adaptive Theme Appearance**:
+The light or dark presentation of a Markdown Theme Preset selected from each viewer's system preference. Appearance is a property of the Preset at viewing time, not a choice stored on the Share.
+_Avoid_: Separate light theme, creator-locked appearance, Share appearance setting
+
+**Theme Reading Baseline**:
+The responsive readability and accessibility contract shared by every Markdown Theme Preset. A Preset may add its own recognizable visual treatment without changing this common reading behavior.
+_Avoid_: Default theme, visual identity, identical component styling
+
+**Theme Asset Boundary**:
+The rule that Markdown Theme Presets express their identity with system font stacks and local styling without introducing theme-specific remote font or visual-asset requests.
+_Avoid_: Brand font copy, theme CDN dependency, remote theme asset
+
+**Theme Expression Boundary**:
+The reading-first limit that keeps Markdown Theme Presets static and restrained while allowing recognizable color, typography, surfaces, and signature elements. Presets do not use continuous motion, particles, large decorative imagery, or intense glow as part of the reading experience.
+_Avoid_: Immersive landing page, animated theme, decorative spectacle
+
+**Theme Sampler**:
+A compact preview beside the Markdown Theme Catalog control that immediately demonstrates the currently selected Preset through one fixed representative Markdown sample. The same single-preview interaction is available when creating or administratively editing a Markdown Share, while actual Share content remains the responsibility of the full Share preview.
+_Avoid_: Theme gallery, theme card grid, full Share preview
+
+**Creator Theme Preference**:
+The most recently selected Markdown Theme Preset remembered by one browser for the next new Markdown Share. It does not change the Catalog fallback or override the Preset already stored on an existing Share.
+_Avoid_: Site default theme, account preference, Share theme
+
 **Favorite Share**:
 A Share collectively marked in the management dashboard for later retrieval. Its favorite status is shared across all dashboard sessions, is a binary classification without time-ordering semantics, and remains independent of public expiration.
 _Avoid_: Personal favorite, bookmarked link

--- a/app.js
+++ b/app.js
@@ -1594,7 +1594,9 @@ app.post('/admin/pages/:id/clone', requireDashboardAdmin, parseSmallForm, requir
       description: page.description,
       createdAt: Date.now(),
       expiresAt: null,
-      markdownTheme: page.markdown_theme
+      markdownTheme: page.code_type === 'markdown'
+        ? resolveMarkdownThemeId(page.markdown_theme)
+        : null
     });
 
     return res.redirect('/admin/pages/' + encodeURIComponent(newId));

--- a/app.js
+++ b/app.js
@@ -11,7 +11,11 @@ const { performance } = require('node:perf_hooks');
 const config = require('./config');
 const { createPageRepository } = require('./models/pageRepository');
 const { detectCodeType, extractCodeBlocks } = require('./utils/codeDetector');
-const { renderContent, escapeHtml, resolveTheme } = require('./utils/contentRenderer');
+const { renderContent, escapeHtml } = require('./utils/contentRenderer');
+const {
+  getMarkdownThemeOptions,
+  resolveMarkdownThemeId
+} = require('./utils/markdownThemeCatalog');
 const { derivePageTitle } = require('./utils/pageTitle');
 const {
   formatManagementDateTime,
@@ -724,7 +728,7 @@ async function createPageFromInput(input) {
   const passwordHash = password ? await hashSecret(password) : null;
   const encryptedPassword = password ? encryptSecret(password) : null;
   const resolvedTheme = normalizedCodeType === 'markdown'
-    ? resolveTheme(markdownTheme || 'random')
+    ? resolveMarkdownThemeId(markdownTheme)
     : null;
   const id = await createPageWithRetry({
     htmlContent,
@@ -1006,7 +1010,8 @@ app.get('/', privateNoStore, requireHomepageAccess, (req, res) => {
   return res.render('index', {
     title: 'QuickShare | 粘贴代码，一键分享',
     page: 'home-page',
-    csrfToken: req.homepageAccessMode === 'locked' ? createCsrfToken(sessionToken) : ''
+    csrfToken: req.homepageAccessMode === 'locked' ? createCsrfToken(sessionToken) : '',
+    markdownThemeOptions: getMarkdownThemeOptions()
   });
 });
 
@@ -1341,7 +1346,9 @@ app.get('/admin/pages/:id', requireDashboardAdmin, async (req, res) => {
       isFavorite: sharedPage.is_favorite === true,
       password: visiblePagePassword(sharedPage),
       expiresAt: sharedPage.expires_at,
-      markdownTheme: sharedPage.markdown_theme
+      markdownTheme: sharedPage.code_type === 'markdown'
+        ? resolveMarkdownThemeId(sharedPage.markdown_theme)
+        : null
     };
     const sessionToken = req.dashboardAdminSession?.token || req.cookies?.[DASHBOARD_ADMIN_COOKIE] || '';
 
@@ -1351,7 +1358,8 @@ app.get('/admin/pages/:id', requireDashboardAdmin, async (req, res) => {
       csrfToken: config.authEnabled ? createCsrfToken(sessionToken) : '',
       sharedPage: pageData,
       pageDataJson: serializeJsonForHtml(pageData),
-      publicUrl: publicPageUrl(req, sharedPage.id)
+      publicUrl: publicPageUrl(req, sharedPage.id),
+      markdownThemeOptions: getMarkdownThemeOptions()
     });
   } catch (error) {
     console.error('Admin page detail failed:', error);
@@ -1444,8 +1452,8 @@ app.put('/admin/pages/:id', requireDashboardAdmin, parseShareJson, requireDashbo
       const parsed = Number.parseInt(expiresAt, 10);
       updateOptions.expiresAt = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
     }
-    if (markdownTheme !== undefined) {
-      updateOptions.markdownTheme = markdownTheme ? resolveTheme(markdownTheme) : null;
+    if (markdownTheme !== undefined && page.code_type === 'markdown') {
+      updateOptions.markdownTheme = resolveMarkdownThemeId(markdownTheme);
     }
 
     if (isProtected !== undefined) {

--- a/docs/adr/0001-share-markdown-theme-structure.md
+++ b/docs/adr/0001-share-markdown-theme-structure.md
@@ -1,0 +1,3 @@
+# Structure Markdown themes as a shared reading baseline with preset signatures
+
+QuickShare Markdown Theme Presets will share one responsive readability and accessibility baseline while each Preset supplies its own brand-inspired visual signature for typography, color, headings, quotations, code, tables, and related rendered elements. This balances recognizable themes with consistent reading behavior and prevents responsive, overflow, dark-mode, and accessibility fixes from being duplicated across every Preset; fully independent stylesheets and token-only themes were rejected because they respectively multiply maintenance risk or erase too much visual distinction.

--- a/docs/superpowers/specs/2026-07-22-markdown-theme-catalog-design.md
+++ b/docs/superpowers/specs/2026-07-22-markdown-theme-catalog-design.md
@@ -1,0 +1,308 @@
+# QuickShare Markdown Theme Catalog 正式规格
+
+- 日期：2026-07-22
+- 状态：正式规格，已批准进入实施拆票
+- 范围：Markdown Share 的主题目录、呈现、创建与后台编辑选择体验；不改变 QuickShare 站点壳层主题
+- 依据：领域词汇、ADR-0001、已通过浏览器验证的十二主题 Prototype findings
+- 发布状态：已发布为 GitHub Issue #10，并拆分为原生子票据
+
+## Problem Statement
+
+QuickShare 目前允许创建者为 Markdown Share 选择 ByteDance、GitHub、Apple、Notion 或 Claude 主题，但主题能力仍以五套独立样式和多处重复选项存在。创建者只能通过普通下拉名称猜测视觉差异，无法在选择时快速比较主题；浏览器也不会记住上一次选择。现有主题对明暗模式、外层画布、代码、表格、Mermaid、移动端溢出和外部字体的处理并不一致，导致同一个 Markdown Share 在不同环境中可能出现阅读体验分裂。
+
+用户希望把 Markdown Theme Catalog 扩充为十二套品牌灵感预设，包括 Raycast、Google、Tesla、Airbnb、Bugatti、Linear 和 PlayStation，同时保留现有五套的 Preset Visual Identity。这些预设必须适合长篇 Markdown 阅读，而不是复刻品牌官网或产品界面；必须在浅色和暗色下保持同一身份；必须通过一个紧凑 Theme Sampler 帮助选择；还必须避免把响应式、无障碍和资源修复复制十二次。
+
+如果只是继续复制独立样式表和手写下拉选项，Catalog 每次扩充都会放大重复、漂移和视觉回归成本。QuickShare 需要把主题从“若干散落 CSS”提升为一个具备稳定 ID、统一目录、共享阅读基线、主题签名和可验证用户行为的产品能力。
+
+## Solution
+
+QuickShare 将提供一个内置、精选的十二项 Markdown Theme Catalog。每个 Markdown Theme Preset 具有稳定 ID、用户可见 Preset Label、浅色与暗色呈现元数据，以及建立在 Theme Reading Baseline 上的 Preset Visual Identity。
+
+创建首页和后台编辑页继续使用紧凑选择器，但在 Markdown 内容场景中增加一个固定、只读的 Theme Sampler。用户切换主题时，Sampler 立即展示同一组标题、正文、链接、引用、代码、表格和图表示例，从而以一致基准比较主题；实际用户正文仍由现有完整安全预览负责。
+
+所有 Preset 根据查看者系统偏好自动选择 Adaptive Theme Appearance，不向 Share 增加明暗字段或手动切换。浏览器只为新建 Markdown Share 记住最近一次选择；后台编辑始终以 Share 已存主题为准。缺失、非法或不可用的主题继续安全回退到 ByteDance 蓝绿。
+
+十二套 Preset 共享响应式、可读性、溢出、焦点、图片、任务项、代码、表格和图表等基线行为；主题签名只负责可辨识的色板、字体栈、密度、圆角、标题、引用、代码与表面语言。全部主题使用系统字体和本地样式，保持静态克制，不增加品牌 Logo、专有字体、品牌图片、复制的产品界面或持续动画。
+
+功能将按内部切片实施，但只有十二套主题、两种外观和创建/编辑/公开链路全部通过验收后才作为一个完整能力发布。
+
+## User Stories
+
+1. As a Markdown Share creator, I want to choose from twelve curated Presets, so that I can match the presentation to the tone of my content.
+2. As a Markdown Share creator, I want every Preset to have a clear brand-inspired label, so that I can understand its direction without treating it as an official brand theme.
+3. As a Markdown Share creator, I want the theme control to appear only when my content is Markdown, so that unrelated HTML, SVG, or standalone Mermaid publishing stays uncluttered.
+4. As a Markdown Share creator, I want a compact Theme Sampler to update immediately when I select a Preset, so that I can compare themes before requesting a full preview.
+5. As a Markdown Share creator, I want every Theme Sampler to use the same fixed representative content, so that visual differences are comparable rather than influenced by different source text.
+6. As a Markdown Share creator, I want the Theme Sampler to remain separate from the full safe Share preview, so that a quick style comparison does not pretend to be a complete rendering of my content.
+7. As a frequent Markdown Share creator, I want my browser to remember my most recently selected Preset, so that the next new Share starts with my usual choice.
+8. As a first-time creator, I want ByteDance 蓝绿 to remain the initial fallback, so that the existing default experience does not change unexpectedly.
+9. As a creator whose browser storage is blocked or corrupted, I want theme selection to remain usable with a safe fallback, so that publishing never depends on local preference storage.
+10. As a creator, I want my selected stable Preset ID to be stored atomically with the Share, so that the public result matches what I chose.
+11. As a creator, I want the full pre-publish preview to render the selected Preset through the existing sandbox, so that I can validate my actual Markdown before publishing.
+12. As a keyboard user, I want the selector and Theme Sampler region to have explicit labels, logical focus order, and visible focus, so that I can choose a theme without a pointer.
+13. As a mobile creator, I want the selector and Theme Sampler to stack at narrow widths, so that the sample remains readable without horizontal scrolling.
+14. As a creator at desktop width, I want the selector and Theme Sampler to share one compact settings region, so that theme choice does not dominate the publishing workflow.
+15. As an administrator editing a Markdown Share, I want to see the Share's stored Preset selected, so that I do not accidentally overwrite it with my browser's creation preference.
+16. As an administrator, I want the same fixed Theme Sampler available while editing, so that create and edit flows explain Presets consistently.
+17. As an administrator, I want saving a new theme to update the existing Share without changing its title, content, password, expiration, or Favorite Share state, so that theme editing remains surgical.
+18. As an administrator editing non-Markdown content, I want theme controls hidden, so that the editor does not offer an inapplicable setting.
+19. As a public Share viewer, I want the selected Preset to follow my system light or dark preference automatically, so that the page is comfortable in my environment.
+20. As a public Share viewer, I want light and dark appearances to retain the same Preset identity, so that adaptive contrast does not turn one theme into a different theme.
+21. As a public Share viewer, I want long text to use a bounded reading column and responsive padding, so that paragraphs remain readable on phones and large screens.
+22. As a public Share viewer, I want wide tables, fenced code, and diagrams contained within their own regions, so that they never cause page-level horizontal scrolling.
+23. As a public Share viewer, I want images to scale within the reading column without distortion, so that visual content does not break the layout.
+24. As a public Share viewer, I want headings, links, muted text, quotations, code, tables, and diagram labels to meet accessible contrast, so that every Preset remains readable rather than merely decorative.
+25. As a motion-sensitive viewer, I want Markdown themes to remain static and restrained, so that choosing a digital or gaming-inspired Preset does not introduce continuous motion or spectacle.
+26. As a privacy-conscious viewer, I want theme identity to use local styling and system fonts, so that opening a themed Share does not add brand-font or image requests to third parties.
+27. As a viewer of an existing ByteDance Share, I want its blue/teal hierarchy and heading signatures to remain recognizable after the migration, so that the Share is not silently redesigned.
+28. As a viewer of an existing GitHub Share, I want its neutral README structure and restrained rules to remain recognizable after the migration, so that its familiar document character is preserved.
+29. As a viewer of an existing Apple Share, I want its spacious, rounded, minimal presentation to remain recognizable after the migration, so that compatibility improvements do not erase its identity.
+30. As a viewer of an existing Notion Share, I want its neutral knowledge surfaces, underlined links, and red inline code to remain recognizable, so that the current note-like identity is preserved.
+31. As a viewer of an existing Claude Share, I want its warm editorial surfaces, serif headings, and terracotta accents to remain recognizable without downloading a remote font, so that identity and resource policy both hold.
+32. As an API client, I want to submit any documented stable Preset ID through the existing Markdown theme field, so that automated publishing can use the expanded Catalog without a new API version.
+33. As an API client, I want existing response fields and metadata shapes to remain unchanged, so that adding Presets does not break integrations.
+34. As a viewer of a Share containing an unknown or legacy-invalid theme value, I want the page to remain readable using ByteDance fallback, so that bad metadata cannot break public rendering.
+35. As a maintainer, I want one authoritative Markdown Theme Catalog to drive rendering and both selectors, so that labels, IDs, stylesheets, and fallback rules cannot drift across surfaces.
+36. As a maintainer, I want responsive and accessibility fixes to live in the Theme Reading Baseline, so that one correction benefits every Preset.
+37. As a maintainer, I want Preset signature rules to remain expressive above the shared baseline, so that twelve themes do not collapse into token-only clones.
+38. As a maintainer, I want Mermaid and syntax highlighting to share rendering logic while consuming Preset-aware presentation tokens, so that technical content matches each theme without twelve runtime implementations.
+39. As a maintainer, I want plain Markdown to continue avoiding Mermaid and syntax-highlight runtime assets when they are unnecessary, so that the expanded Catalog does not regress view performance.
+40. As a release operator, I want all twelve Presets and both appearances accepted before exposure, so that users never encounter a half-migrated Catalog.
+41. As a release operator, I want application rollback to leave stored stable IDs untouched and render unknown new IDs through the existing fallback, so that rollback remains safe without data reversal.
+42. As a product owner, I want the seven new Presets to be distinguishable without logos, proprietary fonts, brand images, or copied product UI, so that the Catalog communicates inspiration without impersonation.
+
+## Implementation Decisions
+
+### 1. Domain and system boundary
+
+- The feature uses the domain terms defined in the QuickShare Sharing Context: Markdown Theme Preset, Preset Visual Identity, Markdown Theme Catalog, Preset Label, Adaptive Theme Appearance, Theme Reading Baseline, Theme Asset Boundary, Theme Expression Boundary, Theme Sampler, and Creator Theme Preference.
+- Markdown content theming remains separate from the QuickShare site-shell theme. No site-shell environment contract, login/admin theme, or global light/dark selector is expanded by this feature.
+- ADR-0001 is authoritative: every Preset shares one responsive readability and accessibility baseline and supplies a separate visual signature. Fully independent theme implementations and token-only clones remain rejected.
+
+### 2. Authoritative Catalog
+
+- Introduce one server-owned Catalog as the authority for stable ID, Preset Label, ordering, local signature asset, and light/dark wrapper metadata.
+- The renderer, homepage selector, admin editor selector, Theme Sampler, request validation, and fallback resolution consume this authority. Templates receive a safe projection of Catalog metadata rather than maintaining their own hard-coded option lists.
+- Browser code uses only metadata projected from the trusted server Catalog. It must not construct stylesheet URLs from arbitrary request or storage strings.
+- Stable IDs and Labels are:
+
+| Stable ID | Preset Label |
+| --- | --- |
+| `bytedance` | ByteDance 蓝绿 |
+| `github` | GitHub 经典 |
+| `apple` | Apple 极简 |
+| `notion` | Notion 笔记 |
+| `claude` | Claude 暖调 |
+| `raycast` | Raycast 专注 |
+| `google` | Google Material |
+| `tesla` | Tesla 黑白 |
+| `airbnb` | Airbnb 暖居 |
+| `bugatti` | Bugatti 蓝曜 |
+| `linear` | Linear 精密 |
+| `playstation` | PlayStation 蓝境 |
+
+- Catalog order follows the table above. A future label change does not change the stable ID or rewrite existing Share data.
+- Missing, empty, `random`, unknown, stale browser, or otherwise invalid values resolve to `bytedance`. New writes persist the resolved stable ID.
+
+### 3. Data and API compatibility
+
+- No database migration or new column is introduced. The existing text theme field remains the persisted source for each Share's Preset selection.
+- Existing browser-create, preview, admin-update, Share API, metadata, and public-view contracts retain their current field names and response shapes.
+- The expanded set of stable IDs is accepted anywhere the existing Markdown theme value is accepted. Theme selection remains applicable only when the content type is Markdown.
+- No appearance value is stored. Light and dark are runtime presentations chosen from the viewer's system preference.
+- Existing rows with null theme values continue to render through ByteDance fallback. Rendering a fallback must not silently rewrite stored data.
+- Admin editing initializes from the Share's stored value after Catalog resolution. Creator Theme Preference never overrides an existing Share.
+
+### 4. Shared reading baseline
+
+- Load the Theme Reading Baseline independently from the selected Preset signature so that the document remains readable even if a signature asset fails to load.
+- The baseline owns box sizing, `min-width` containment, safe text wrapping, bounded reading width, responsive padding, focus-visible treatment, image sizing, task-item normalization, and the containment behavior of tables, fenced code, and diagrams.
+- Tables, code, and diagrams scroll or reflow inside their own containers; they never create page-level horizontal scrolling. Representative diagrams stack vertically at narrow mobile width.
+- Baseline tokens cover at least canvas, primary text, muted text, accent/link, borders, quotations, tables, diagrams, code foreground/background, focus, and heading-on-accent foreground.
+- The public Markdown wrapper derives page background, supported color scheme, and browser theme-color metadata from the resolved Preset's light/dark Catalog metadata instead of using one hard-coded wrapper palette.
+- Shared baseline behavior applies equally to public Shares, full safe previews, and the fixed Theme Sampler, with context-specific scale permitted where needed.
+
+### 5. Adaptive appearance
+
+- Every Preset provides coherent light and dark token sets. The browser selects between them using system color-scheme preference.
+- Adaptive Theme Appearance does not add a creator control, Share setting, URL parameter, cookie, API field, or database value.
+- The prototype's explicit appearance override was a disposable inspection tool and is not a production feature.
+- A Preset's hue emphasis, radius language, heading construction, surface depth, and density remain paired across light and dark even when contrast polarity changes.
+- Gradient or accent headings must declare a contrast-safe foreground for each appearance; a light-mode accent color cannot be reused blindly in dark appearance.
+
+### 6. Preset signatures
+
+- Existing Presets retain these identities while adopting the shared baseline and adaptive appearance:
+  - **ByteDance 蓝绿:** contrast-safe blue/teal hierarchy, gradient second-level heading, bordered third-level heading, quotation accent, and code-top accent; malformed decorative characters and broad blur glow are removed.
+  - **GitHub 经典:** neutral canvas, fine rules, compact document rhythm, restrained blue links, small-radius surfaces, and no decorative gradient or shadow.
+  - **Apple 极简:** relaxed 17 px body rhythm, narrower reading column, generous spacing, soft 12–16 px surfaces, plain headings, and minimal borders.
+  - **Notion 笔记:** warm-neutral canvas, small corners, structured gray surfaces, underlined body-color links, red inline code, and explicit task state.
+  - **Claude 暖调:** warm paper/dark-brown surfaces, system-serif headings, terracotta links and quotations, and system monospace only.
+- New Presets use these approved directions:
+  - **Raycast 专注:** graphite/plum base, restrained violet/magenta tonal depth, tool-like 12 px surfaces, and inset highlights; no animated glow or floating-glass spectacle.
+  - **Google Material:** tonal surfaces, expressive asymmetric corner language, blue primary with a controlled secondary marker, and a clear type scale; not a multicolor brand collage.
+  - **Tesla 黑白:** hard black/white hierarchy, bold uppercase long-form first-level heading, thin specification rules, and minimal ornament; its Theme Sampler scale is smaller than its long-form display scale.
+  - **Airbnb 暖居:** cream/warm-neutral canvas, dark terracotta accent, friendly 18 px surfaces, a metadata pill, and shallow shadow; no copied Airbnb search/home interface or prominent Rausch-pink imitation.
+  - **Bugatti 蓝曜:** ice-white/carbon-black polarity, vivid blue focus, fine metallic separators, and a restrained angular facet; no vehicle imagery, badge, texture asset, or intense shine.
+  - **Linear 精密:** calm 15 px density, cool-gray canvas, violet/blue hairlines, precise 7 px surfaces, and minimal depth; flatter and less saturated than Raycast.
+  - **PlayStation 蓝境:** pale/deep-blue polarity, static geometric facet, blue gradient heading, and bright focus; dark appearance uses a contrast-safe foreground on the bright gradient and contains no neon bloom, particles, or entertainment artwork.
+- Preset signatures may style typography, color, headings, quotations, code, tables, diagrams, links, and related surfaces, but cannot override baseline containment, accessibility, or responsive contracts.
+
+### 7. Theme Asset and Expression Boundaries
+
+- Presets use system font stacks and local CSS only. Remove the existing theme-specific remote font import rather than extending that pattern.
+- Do not add logos, brand images, copied application screens, vehicle/property/game imagery, proprietary fonts, or theme-specific third-party assets.
+- Existing conditional Mermaid and syntax-highlight runtimes remain outside the Theme Asset Boundary. Their presentation becomes Catalog-aware through shared local styles and Preset tokens; do not add separate runtime implementations or per-Preset CDN assets.
+- Plain Markdown continues to omit Mermaid and syntax-highlight runtimes when the content does not require them.
+- Presets contain no continuous animation, particles, large decorative images, intense glow, or immersive landing-page behavior. Static gradients, subtle shadows, inset highlights, and restrained geometric facets are allowed.
+
+### 8. Theme Sampler
+
+- Render one Theme Sampler with the selector in both the Markdown create flow and Markdown admin-edit flow.
+- The Sampler uses one fixed, read-only representative sample covering heading hierarchy, body text, emphasis, link, list, quotation, inline code, fenced code, table, task state, keyboard hint, image treatment, divider, and a representative diagram surface.
+- The Sampler does not inject or render the user's current Markdown and does not execute Mermaid or syntax-highlight runtimes. Actual content remains the responsibility of the full safe Share preview.
+- The Sampler loads only trusted local baseline/signature presentation for the currently selected Catalog entry.
+- Sampler typography uses a compact context-specific scale while preserving the selected Preset's weight, case, rules, color, radius, and surface signatures. Long-form display sizes must not be copied blindly into the compact sample.
+- At 375 px the selector and Sampler stack vertically. At wider create/admin settings widths they may sit adjacent when the sample retains a useful reading width. The interaction must not introduce page-level overflow at 375, 768, or 1440 px.
+- The selector has an explicit label; the Sampler has an accessible name describing the selected Preset and remains outside sequential focus unless it contains an intentionally interactive demonstration. Its fixed content is not announced as user content.
+- Switching Presets updates the Sampler immediately without requesting the full preview endpoint or mutating Share content.
+
+### 9. Creator Theme Preference
+
+- Only the new-Share browser flow reads and writes Creator Theme Preference.
+- Selecting a valid Preset remembers its stable ID in browser-local storage for the next new Markdown Share. Clearing editor content or leaving the page does not reset the preference.
+- On a later homepage visit, a valid remembered ID is preselected when Markdown controls become applicable. Missing, invalid, removed, or inaccessible storage falls back to ByteDance without showing an error or blocking publishing.
+- The browser preference is convenience state, not source of truth. The selected ID is still sent with preview/create requests and validated by the server Catalog.
+- Admin editing neither reads nor writes Creator Theme Preference.
+
+### 10. Mermaid and syntax highlighting
+
+- One shared Mermaid configuration consumes resolved light/dark diagram tokens from the selected Catalog entry. Presets do not fork diagram rendering logic.
+- One shared syntax presentation consumes code tokens from the selected Preset while retaining content-language highlighting behavior.
+- The same resolved Preset and appearance govern Markdown text, code, tables, and embedded Mermaid so a Share does not mix unrelated palettes.
+- Runtime loading remains conditional on content. Failures of optional Mermaid or syntax-highlight runtimes degrade safely without making the surrounding document unreadable.
+
+### 11. Failure and compatibility behavior
+
+| Scenario | Required behavior |
+| --- | --- |
+| Theme omitted or `random` | Resolve and persist ByteDance for new writes. |
+| Unknown request value | Resolve to ByteDance; never construct an arbitrary asset URL. |
+| Existing row contains null or unknown value | Render readable ByteDance fallback without rewriting the row during a read. |
+| Browser preference is stale or malformed | Ignore it and preselect ByteDance. |
+| Browser storage throws or is unavailable | Continue selection, preview, and publishing without persistence. |
+| Preset signature asset fails | Shared baseline keeps the document readable and contained. |
+| Optional Mermaid/highlight runtime fails | Technical content degrades safely; the document and selected Preset remain usable. |
+| System appearance changes while viewing | The resolved Preset changes appearance without changing its stored ID or reloading Share data. |
+| Application rolls back after new IDs were stored | Older code may display ByteDance fallback, but stored IDs remain intact for a later forward deployment. |
+
+### 12. Delivery boundary
+
+- Implement in reviewable internal slices, but do not expose a partially migrated Catalog as the completed feature.
+- Release acceptance requires all twelve Presets, both appearances, create/admin Samplers, browser preference, preview/create/edit persistence, public rendering, and compatibility checks to pass together.
+- The disposable Prototype is evidence only. Do not copy its production-shaped code into the implementation; retain only approved visual decisions and test constraints.
+- No database migration, background job, data backfill, authentication change, deployment-platform migration, or public URL change is required.
+
+## Testing Decisions
+
+### 1. Testing philosophy and seams
+
+- Tests assert external behavior: accepted Catalog IDs, rendered document semantics, selected/persisted values, resource requests, accessible interaction, computed contrast, responsive geometry, and fallback behavior. They do not require a particular number of stylesheets, exact selector text, or pixel-identical screenshots.
+- Prefer three existing seams:
+  1. **HTTP/render seam:** exercise homepage, preview, create, metadata, admin detail/update, and public view through the running Express application.
+  2. **Browser seam:** exercise selection, Sampler, local preference, system appearance, real geometry, resource inventory, and public Share output in a real browser.
+  3. **Content-renderer seam:** exercise Catalog resolution, conditional optional assets, wrapper metadata, Mermaid/highlight configuration, and readable fallback without involving persistence.
+- No new database test seam is required because the persisted field and Repository behavior already exist. Existing Memory/Postgres theme persistence coverage remains part of the full regression suite.
+
+### 2. Catalog and renderer contracts
+
+- Table-drive all twelve stable IDs and Labels through Catalog resolution.
+- Assert IDs are unique, labels are non-empty, projected assets are local trusted paths, both appearance metadata sets exist, and fallback is ByteDance.
+- For each stable ID, render representative Markdown and verify the resolved document references the shared baseline plus the correct trusted signature and appearance metadata.
+- Verify null, empty, `random`, unknown, and malformed values render ByteDance without reflecting arbitrary input into asset URLs.
+- Verify plain Markdown requests no Mermaid or syntax-highlight runtime; code-only Markdown loads highlighting but not Mermaid; Mermaid Markdown loads Mermaid but not unrelated highlighting.
+- Verify no rendered Preset introduces remote font, logo, image, or theme-specific CDN requests.
+- Verify a missing or failed signature leaves baseline text, tables, code, images, and diagrams contained and readable.
+
+### 3. Create, preview, API, and edit behavior
+
+- Homepage HTML exposes all twelve options from the Catalog in the approved order and displays the control only for Markdown content.
+- Preview each new stable ID through the existing preview endpoint and verify the sandboxed document uses that Preset without storing a Share.
+- Create Markdown Shares through the browser endpoint and Share API using representative existing and new IDs; verify the resolved stable ID is persisted and returned through existing metadata fields.
+- Submit unknown values through all write paths and verify ByteDance normalization rather than arbitrary persistence or asset loading.
+- Render a persisted new ID through the public view and verify the same Preset identity appears in the public document.
+- Admin detail initializes from the Share's stored Preset; updating only the Preset preserves content, title, description, password/protection, expiration, view data, and Favorite Share state.
+- Non-Markdown create/edit flows omit inapplicable theme UI and do not gain a theme side effect.
+
+### 4. Theme Sampler and Creator Theme Preference
+
+- In a real browser, switching any of the twelve options updates one fixed Sampler immediately without calling the full preview endpoint or altering editor content.
+- Verify the fixed sample contains the agreed representative roles and remains read-only.
+- Verify the selector is keyboard-operable, visibly focused, explicitly labeled, and correctly associated with the Sampler's accessible name.
+- Verify the Sampler uses context-specific scale: Tesla and other display-heavy themes remain compact while retaining their signature.
+- Verify selecting a valid ID on the homepage is remembered and preselected on the next new Markdown session.
+- Verify stale IDs, malformed storage, denied storage, and thrown storage access all fall back safely without blocking preview or publishing.
+- Verify admin edit ignores and does not mutate Creator Theme Preference.
+
+### 5. Production visual matrix
+
+- Run a real-browser matrix covering twelve Presets × two appearances × 375, 768, and 1440 px: 72 full combinations for the Sampler and representative rendered Markdown.
+- At every combination, assert zero page-level horizontal overflow and containment of tables, fenced code, images, task items, and diagrams.
+- At 375 px assert selector/Sampler vertical stacking and vertically reflowed representative diagram behavior. At wider sizes assert the settings region remains compact and the reading column bounded.
+- Test browser system-appearance changes and verify one stable Preset ID retains its visual identity while computed colors switch.
+- Measure representative contrast roles. Normal body, link, quotation, muted, code, table, and diagram text must meet at least WCAG AA 4.5:1; qualifying large display text must meet at least 3:1. Focus indicators must remain visible in every appearance.
+- Use computed style and signature assertions for durable visual contracts, supplemented by contact-sheet human review. Do not make a full-page pixel snapshot the sole source of truth.
+- Repeat key creator/admin/public flows at 200% zoom to catch reflow and clipping beyond viewport-width checks.
+
+### 6. Preset identity acceptance
+
+- Existing five Presets retain their approved signature anchors after baseline migration.
+- The seven new Presets remain distinguishable without their visible labels, logos, brand images, proprietary fonts, or motion.
+- Raycast and Linear must remain distinct: Raycast uses deeper/inset tool surfaces and stronger plum tonal depth; Linear stays flatter, denser, and less saturated.
+- Tesla long-form display hierarchy must not inflate the compact Sampler.
+- Airbnb uses warm terracotta rather than copied Rausch-pink identity.
+- Bugatti and PlayStation use distinct blue systems: Bugatti is metallic/ice-carbon restraint; PlayStation is geometric blue depth.
+- ByteDance removes malformed decorative glyphs and broad blur while preserving blue/teal hierarchy.
+- Claude preserves warm editorial identity after remote font removal.
+
+### 7. Resource, performance, and regression checks
+
+- Browser network inventory for every Preset contains no theme-specific remote font, image, stylesheet, or script request.
+- Static and computed inspection finds no continuous animation or prohibited visual effects in theme presentation.
+- Plain Markdown keeps the current optional-asset performance behavior; expanding the Catalog must not cause all twelve signatures or optional runtimes to download on every public view.
+- Run the complete Node test suite and existing PostgreSQL integration suite even though no migration is added.
+- Regress HTML, SVG, standalone Mermaid, safe preview sandboxing, password protection, expiration, view counts, public metadata, Share API compatibility, admin access, and Favorite Share lifecycle.
+- Before release, verify the same reviewed revision in Preview and Production, including custom-domain public rendering and local-versus-deployed theme asset integrity.
+
+### 8. Prior art
+
+- Existing content-renderer tests already cover conditional Mermaid/highlight assets and plain-Markdown resource behavior.
+- Existing publishing UX tests already exercise the homepage, sandboxed preview endpoint, and Markdown theme request.
+- Existing access-policy tests already prove browser and Share API theme persistence through HTTP and Repository readback.
+- Existing admin accessibility tests provide patterns for labeled controls, focus visibility, responsive layout, and busy/live states.
+- Existing production acceptance practice provides browser matrices, asset-integrity checks, custom-domain smoke tests, and compatibility regression boundaries.
+
+## Out of Scope
+
+- User-authored themes, theme editor, custom CSS upload, marketplace, import/export, or third-party theme installation.
+- Brand replication, official-looking themes, logos, badges, proprietary fonts, copied application interfaces, product screenshots, vehicles, properties, game art, or other brand imagery.
+- Creator-selected or Share-stored light/dark appearance, manual appearance toggles, URL appearance parameters, or separate light/dark Catalog entries.
+- Changes to QuickShare site-shell themes, `UI_THEME`, login/admin shell appearance, or global application color-mode behavior.
+- Live rendering of user Markdown inside Theme Sampler; the existing full safe preview remains the only actual-content preview.
+- Continuous animation, particles, animated glow, large decorative background imagery, or immersive landing-page behavior.
+- Database migration, data backfill, new table/column, Repository redesign, or cache-backed theme source of truth.
+- New authentication, authorization, CSRF, password, expiration, Favorite Share, analytics, or view-count behavior.
+- New public routes, Share URL changes, API versioning, or response-shape changes.
+- Replacing the existing Markdown, Mermaid, or syntax-highlight parser/runtime libraries solely for theme support.
+- Treating the disposable Prototype Theme Lab as production code or shipping its manual appearance override.
+- Implementing production code, pushing, or deploying as part of the specification and ticket-publication workflow.
+
+## Further Notes
+
+- The visual Prototype validated the architecture before this specification. Across 72 single-view combinations and a 24-card comparison, it found zero page-level overflow and zero table/code/diagram containment failures.
+- Prototype contrast minima were body 7.10:1, heading 12.26:1, link 4.73:1, quotation 5.25:1, fenced code 11.35:1, muted text 4.51:1, diagram node 12.26:1, and table header 11.35:1. These values demonstrate viability but do not replace production WCAG verification.
+- The prototype rejected an oversized Tesla Sampler heading. With a sampler-specific scale, all twelve light samplers measured 395–414 px tall at a 392 px rendered width and 387–406 px tall at a 318 px mobile width.
+- Prototype inspection found no remote URL, font import, keyframe, animation declaration, or console error. Production must independently prove the same Theme Asset and Expression Boundaries.
+- Official primary-source checks informed brand direction, but the implemented Presets remain QuickShare's own brand-inspired visual language. Future changes to brand websites do not create an obligation to track or reproduce them.
+- The disposable Theme Lab should be removed only in a later authorized cleanup after this specification and its visual findings are safely carried into tickets. It is intentionally not modified or deleted by this specification-only task.
+- Implementation proceeds through the independently verifiable child tickets attached to GitHub Issue #10. They are already agent-ready and must not be sent through triage.

--- a/public/css/markdown-airbnb.css
+++ b/public/css/markdown-airbnb.css
@@ -1,0 +1,300 @@
+/* Airbnb 暖居 — warm, hospitable Markdown signature */
+
+:root {
+  --theme-canvas: #fff8f2;
+  --theme-text: #3e302c;
+  --theme-muted: #6f5a54;
+  --theme-heading: #2d211e;
+  --theme-link: #873527;
+  --theme-accent: #963f30;
+  --theme-focus: #873527;
+  --theme-border: #d7c2b9;
+  --theme-soft-surface: #fffdf9;
+  --theme-quote-text: #654b43;
+  --theme-quote-surface: #f7e7dc;
+  --theme-table-surface: #fffdf9;
+  --theme-table-heading: #3a2924;
+  --theme-table-heading-surface: #f7e8de;
+  --theme-code-text: #fff5ed;
+  --theme-code-surface: #2f2421;
+  --theme-heading-on-accent: #fffaf6;
+  --theme-diagram-text: #3a2924;
+  --theme-diagram-surface: #fffdf9;
+  --theme-diagram-node-surface: #f5e6dc;
+  --theme-diagram-node-border: #963f30;
+  --theme-diagram-line: #806b63;
+  --theme-diagram-label-surface: #fffdf9;
+  --theme-syntax-comment: #c9b7ae;
+  --theme-syntax-keyword: #f4a58d;
+  --theme-syntax-string: #b7d795;
+  --theme-syntax-number: #dcb7ef;
+  --theme-syntax-title: #f0c28f;
+  --theme-syntax-meta: #dfb4d4;
+  --theme-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-reading-width: 820px;
+  --theme-surface-shadow: 0 4px 14px rgba(87, 53, 42, 0.08);
+}
+
+.markdown-body {
+  font-family: var(--theme-font-family);
+  font-size: 17px;
+  line-height: 1.72;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5) {
+  color: var(--theme-heading);
+  font-weight: 650;
+  line-height: 1.24;
+  letter-spacing: -0.018em;
+}
+
+.markdown-body h1 {
+  margin: 0 0 1.25em;
+  padding: 0.78em 0.9em;
+  font-size: clamp(2rem, 5vw, 2.7rem);
+  background: var(--theme-soft-surface);
+  border: 1px solid var(--theme-border);
+  border-bottom: 5px solid var(--theme-accent);
+  border-radius: 18px;
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body h2 {
+  margin: 2.15em 0 0.8em;
+  padding-bottom: 0.4em;
+  font-size: clamp(1.45rem, 3.2vw, 1.75rem);
+  border-bottom: 2px solid #c9917f;
+}
+
+.markdown-body h3 {
+  margin: 1.85em 0 0.68em;
+  color: var(--theme-accent);
+  font-size: 1.24rem;
+}
+
+.markdown-body :where(h4, h5) {
+  margin: 1.55em 0 0.5em;
+}
+
+.markdown-body h6 {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin: 1.5em 0 0.7em;
+  padding: 0.28em 0.7em;
+  color: var(--theme-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--theme-quote-surface);
+  border: 1px solid #d7ae9f;
+  border-radius: 999px;
+}
+
+.markdown-body p {
+  margin: 0 0 1.12em;
+}
+
+.markdown-body a {
+  font-weight: 600;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-heading);
+  font-weight: 700;
+}
+
+.markdown-body blockquote {
+  margin: 1.4em 0;
+  padding: 1.05em 1.2em;
+  color: var(--theme-quote-text);
+  background: var(--theme-quote-surface);
+  border: 1px solid #e0c4b8;
+  border-left: 5px solid var(--theme-accent);
+  border-radius: 18px;
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.12em;
+  padding-left: 1.65em;
+}
+
+.markdown-body li {
+  margin: 0.34em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 2.35em 0;
+  background: var(--theme-border);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.14em 0.4em;
+  color: #713326;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.86em;
+  background: #f5e4d8;
+  border-radius: 7px;
+}
+
+.markdown-body pre {
+  margin: 1.4em 0;
+  padding: 1.15em 1.25em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88rem;
+  line-height: 1.65;
+  background: var(--theme-code-surface);
+  border: 1px solid #5b4740;
+  border-radius: 18px;
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 1.4em 0;
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 18px;
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.72em 0.9em;
+  text-align: left;
+  border-color: #dfcec7;
+}
+
+.markdown-body th {
+  color: var(--theme-table-heading);
+  font-weight: 650;
+  background: var(--theme-table-heading-surface);
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: #fff9f4;
+}
+
+.markdown-body :where(img, .mermaid) {
+  border-radius: 18px;
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body img {
+  margin: 1.5em auto;
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.14em 0.44em;
+  color: var(--theme-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8em;
+  background: var(--theme-soft-surface);
+  border: 1px solid var(--theme-border);
+  border-bottom-width: 2px;
+  border-radius: 7px;
+}
+
+.markdown-body mark {
+  padding: 0.08em 0.25em;
+  color: var(--theme-heading);
+  background: #f2d6a8;
+  border-radius: 5px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #211a18;
+    --theme-text: #f2e6df;
+    --theme-muted: #c4aea4;
+    --theme-heading: #fff8f2;
+    --theme-link: #f1aa93;
+    --theme-accent: #e89c84;
+    --theme-focus: #f1aa93;
+    --theme-border: #74584f;
+    --theme-soft-surface: #2d2421;
+    --theme-quote-text: #eadbd4;
+    --theme-quote-surface: #392824;
+    --theme-table-surface: #2b2320;
+    --theme-table-heading: #fff8f2;
+    --theme-table-heading-surface: #3a2b27;
+    --theme-code-text: #fff5ed;
+    --theme-code-surface: #120e0d;
+    --theme-heading-on-accent: #2b1510;
+    --theme-diagram-text: #fff1e9;
+    --theme-diagram-surface: #2b2320;
+    --theme-diagram-node-surface: #402d28;
+    --theme-diagram-node-border: #e89c84;
+    --theme-diagram-line: #c0a59a;
+    --theme-diagram-label-surface: #2b2320;
+    --theme-syntax-comment: #bca79e;
+    --theme-syntax-keyword: #f4aa93;
+    --theme-syntax-string: #b9db9b;
+    --theme-syntax-number: #d9b9eb;
+    --theme-syntax-title: #efc18e;
+    --theme-syntax-meta: #dfb9d3;
+    --theme-surface-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  .markdown-body h2 {
+    border-color: #9f6758;
+  }
+
+  .markdown-body h6 {
+    border-color: #815c51;
+  }
+
+  .markdown-body blockquote {
+    border-color: #684a42;
+    border-left-color: var(--theme-accent);
+  }
+
+  .markdown-body code {
+    color: #f4c7b8;
+    background: #4a3029;
+  }
+
+  .markdown-body :where(th, td) {
+    border-color: #58443e;
+  }
+
+  .markdown-body th {
+    background: var(--theme-table-heading-surface);
+  }
+
+  .markdown-body tbody tr:nth-child(even) {
+    background: #302522;
+  }
+
+  .markdown-body mark {
+    color: #fff3e8;
+    background: #684b26;
+  }
+}

--- a/public/css/markdown-apple.css
+++ b/public/css/markdown-apple.css
@@ -51,6 +51,7 @@
   overflow: auto;
   font-size: 14px;
   line-height: 1.5;
+  color: #1d1d1f;
   background-color: #f5f5f7;
   border-radius: 12px;
   font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;

--- a/public/css/markdown-apple.css
+++ b/public/css/markdown-apple.css
@@ -1,148 +1,229 @@
-/* ===== Apple 极简 Markdown 主题 ===== */
-.markdown-body {
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  font-size: 17px;
-  line-height: 1.5;
-  color: #1d1d1f;
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 40px 20px;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* Apple 极简 — QuickShare brand-inspired Markdown signature */
+
+:root {
+  --theme-canvas: #ffffff;
+  --theme-text: #1d1d1f;
+  --theme-muted: #515154;
+  --theme-accent: #0066cc;
+  --theme-link: #0066cc;
+  --theme-border: #d2d2d7;
+  --theme-quote-surface: #f5f5f7;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #f5f5f7;
+  --theme-code-text: #1d1d1f;
+  --theme-code-surface: #f5f5f7;
+  --theme-focus: #0066cc;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Helvetica, Arial, sans-serif;
+  --theme-diagram-text: #1d1d1f;
+  --theme-diagram-node-surface: #ffffff;
+  --theme-diagram-node-border: #6e6e73;
+  --theme-diagram-line: #6e6e73;
+  --theme-diagram-label-surface: #f5f5f7;
+  --theme-reading-width: 800px;
+  --theme-syntax-comment: #6e6e73;
+  --theme-syntax-keyword: #9a1b1e;
+  --theme-syntax-string: #16712d;
+  --theme-syntax-number: #0057a8;
+  --theme-syntax-title: #6e3ca0;
+  --theme-syntax-meta: #8a3b12;
 }
 
-.markdown-body h1, .markdown-body h2, .markdown-body h3,
-.markdown-body h4, .markdown-body h5, .markdown-body h6 {
+.markdown-body {
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: -0.006em;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
   margin-top: 2em;
-  margin-bottom: 0.5em;
+  margin-bottom: 0.55em;
+  color: var(--theme-text);
   font-weight: 600;
-  line-height: 1.2;
-  color: #1d1d1f;
+  line-height: 1.18;
   letter-spacing: -0.022em;
 }
 
-.markdown-body h1 { font-size: 2em; margin-top: 0; }
-.markdown-body h2 { font-size: 1.5em; margin-top: 1.75em; }
-.markdown-body h3 { font-size: 1.25em; margin-top: 1.5em; }
-.markdown-body h4 { font-size: 1em; }
+.markdown-body h1 {
+  margin-top: 0;
+  font-size: clamp(2rem, 5vw, 2.5rem);
+}
+
+.markdown-body h2 {
+  font-size: clamp(1.5rem, 3.5vw, 1.85rem);
+}
+
+.markdown-body h3 {
+  font-size: 1.3rem;
+}
+
+.markdown-body :where(h4, h5, h6) {
+  font-size: 1rem;
+}
 
 .markdown-body p {
-  margin-top: 0;
-  margin-bottom: 1.5em;
-  line-height: 1.6;
-}
-
-.markdown-body blockquote {
-  margin: 0 0 1.5em 0;
-  padding: 20px;
-  background: #f5f5f7;
-  border-radius: 16px;
-  color: #1d1d1f;
-  font-style: normal;
-}
-
-.markdown-body strong { font-weight: 600; color: #1d1d1f; }
-.markdown-body em { font-style: italic; }
-
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 1.5em;
-  padding: 16px 20px;
-  overflow: auto;
-  font-size: 14px;
-  line-height: 1.5;
-  color: #1d1d1f;
-  background-color: #f5f5f7;
-  border-radius: 12px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;
-}
-
-.markdown-body code {
-  font-size: 90%;
-  padding: 2px 6px;
-  background: #f5f5f7;
-  border-radius: 6px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;
-}
-
-.markdown-body pre code {
-  padding: 0;
-  background: transparent;
-  border-radius: 0;
-  font-size: 100%;
+  margin: 0 0 1.5em;
 }
 
 .markdown-body a {
-  color: #007AFF;
-  text-decoration: none;
-  transition: opacity 0.15s ease;
+  color: var(--theme-link);
 }
 
-.markdown-body a:hover { opacity: 0.8; }
-
-.markdown-body img {
-  max-width: 100%;
-  border-radius: 16px;
-  display: block;
-  margin: 1.5em auto;
-}
-
-.markdown-body table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  margin-bottom: 1.5em;
-  overflow: hidden;
-  border-radius: 12px;
-}
-
-.markdown-body th, .markdown-body td {
-  padding: 12px 16px;
-  text-align: left;
-}
-
-.markdown-body th {
+.markdown-body :where(strong, b) {
+  color: var(--theme-text);
   font-weight: 600;
-  background: #f5f5f7;
-  color: #1d1d1f;
 }
 
-.markdown-body td {
-  border-top: 1px solid rgba(0,0,0,0.04);
-  color: #1d1d1f;
+.markdown-body blockquote {
+  margin: 0 0 1.5em;
+  padding: 1.2em 1.35em;
+  color: var(--theme-text);
+  background: var(--theme-quote-surface);
+  border: 0;
+  border-radius: 16px;
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.5em;
+  padding-left: 1.7em;
+}
+
+.markdown-body li {
+  margin: 0.35em 0;
 }
 
 .markdown-body hr {
   height: 1px;
-  padding: 0;
-  margin: 2em 0;
-  background: #e0e0e0;
+  margin: 2.5em 0;
+  background: var(--theme-border);
   border: 0;
 }
 
-.markdown-body ul, .markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 1.5em;
-  padding-left: 2em;
+.markdown-body code {
+  padding: 0.16em 0.42em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.88em;
+  background: var(--theme-code-surface);
+  border-radius: 6px;
 }
 
-.markdown-body li { margin-bottom: 0.25em; }
+.markdown-body :where(pre, table) {
+  border-radius: 12px;
+}
+
+.markdown-body pre {
+  margin: 0 0 1.5em;
+  padding: 1.1em 1.25em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  background: var(--theme-code-surface);
+  border: 0;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 0 0 1.5em;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.8em 1em;
+  text-align: left;
+  border: 0;
+  border-top: 1px solid var(--theme-border);
+}
+
+.markdown-body tr:first-child :where(th, td) {
+  border-top: 0;
+}
+
+.markdown-body th {
+  font-weight: 600;
+  background: var(--theme-quote-surface);
+}
+
+.markdown-body img {
+  margin: 1.75em auto;
+  border-radius: 16px;
+}
 
 .markdown-body kbd {
   display: inline-block;
-  padding: 3px 8px;
-  font-size: 12px;
+  padding: 0.2em 0.5em;
+  color: var(--theme-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.75em;
   line-height: 1.3;
-  color: #1d1d1f;
-  background: #f5f5f7;
-  border: 1px solid #e0e0e0;
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-border);
   border-radius: 6px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;
 }
 
 .markdown-body mark {
-  background: rgba(0, 122, 255, 0.1);
-  color: #1d1d1f;
-  padding: 0 4px;
+  padding: 0.08em 0.25em;
+  color: var(--theme-text);
+  background: #fff3a8;
   border-radius: 4px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+.markdown-body .mermaid {
+  padding: 1em;
+  border: 0;
+  border-radius: 16px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #000000;
+    --theme-text: #f5f5f7;
+    --theme-muted: #a1a1a6;
+    --theme-accent: #2997ff;
+    --theme-link: #2997ff;
+    --theme-border: #424245;
+    --theme-quote-surface: #1c1c1e;
+    --theme-table-surface: #000000;
+    --theme-diagram-surface: #1c1c1e;
+    --theme-code-text: #f5f5f7;
+    --theme-code-surface: #1c1c1e;
+    --theme-focus: #2997ff;
+    --theme-heading-on-accent: #000000;
+    --theme-diagram-text: #f5f5f7;
+    --theme-diagram-node-surface: #000000;
+    --theme-diagram-node-border: #a1a1a6;
+    --theme-diagram-line: #a1a1a6;
+    --theme-diagram-label-surface: #1c1c1e;
+    --theme-syntax-comment: #a1a1a6;
+    --theme-syntax-keyword: #ff6961;
+    --theme-syntax-string: #7ee787;
+    --theme-syntax-number: #64d2ff;
+    --theme-syntax-title: #d0a8ff;
+    --theme-syntax-meta: #ffb366;
+  }
+
+  .markdown-body mark {
+    color: #f5f5f7;
+    background: #6b5b00;
+  }
 }

--- a/public/css/markdown-bugatti.css
+++ b/public/css/markdown-bugatti.css
@@ -1,0 +1,289 @@
+/* Bugatti 蓝曜 — ice, carbon, blue, and restrained metal */
+
+:root {
+  --theme-canvas: #f4f8fc;
+  --theme-text: #171b21;
+  --theme-muted: #505b68;
+  --theme-heading: #0b0e12;
+  --theme-carbon: #0b0e12;
+  --theme-ice: #f4f8fc;
+  --theme-accent: #0057ff;
+  --theme-link: #0048bd;
+  --theme-focus: #0057ff;
+  --theme-metal: #8996a5;
+  --theme-border: #aab5c1;
+  --theme-quote-surface: #e9f0f7;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #ffffff;
+  --theme-diagram-text: #171b21;
+  --theme-diagram-node-surface: #eaf2fb;
+  --theme-diagram-node-border: #0057ff;
+  --theme-diagram-line: #5b6876;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-code-text: #eef5ff;
+  --theme-code-surface: #0b0e12;
+  --theme-heading-on-accent: #ffffff;
+  --theme-syntax-comment: #aeb8c5;
+  --theme-syntax-keyword: #8db8ff;
+  --theme-syntax-string: #b8d7ff;
+  --theme-syntax-number: #ffffff;
+  --theme-syntax-title: #6fa5ff;
+  --theme-syntax-meta: #d4e5ff;
+  --theme-reading-width: 900px;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+}
+
+.markdown-body {
+  color: var(--theme-text);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 680;
+  line-height: 1.14;
+  letter-spacing: -0.012em;
+}
+
+.markdown-body h1 {
+  margin: 0 0 1em;
+  padding: 0.65em 0.78em;
+  color: var(--theme-heading-on-accent);
+  font-size: clamp(2.35rem, 5.8vw, 4.4rem);
+  font-weight: 760;
+  letter-spacing: -0.035em;
+  background: var(--theme-carbon);
+  border-left: 4px solid var(--theme-accent);
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 0 100%);
+}
+
+.theme-sampler .markdown-body h1,
+.markdown-theme-sampler .markdown-body h1 {
+  padding: 0.55em 0.65em;
+  font-size: clamp(1.5rem, 4vw, 2.35rem);
+}
+
+.markdown-body h2 {
+  margin: 2.35em 0 0.8em;
+  padding-bottom: 0.38em;
+  font-size: clamp(1.55rem, 3vw, 1.95rem);
+  border-bottom: 1px solid var(--theme-metal);
+}
+
+.markdown-body h3 {
+  margin: 1.95em 0 0.65em;
+  padding-left: 0.62em;
+  font-size: 1.24rem;
+  border-left: 2px solid var(--theme-accent);
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.65em 0 0.55em;
+}
+
+.markdown-body p {
+  margin: 0 0 1.15em;
+}
+
+.markdown-body a {
+  color: var(--theme-link);
+  font-weight: 650;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--theme-metal);
+}
+
+.markdown-body a:hover {
+  color: var(--theme-accent);
+  text-decoration-color: currentColor;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-heading);
+  font-weight: 760;
+}
+
+.markdown-body blockquote {
+  margin: 1.5em 0;
+  padding: 0.9em 1.05em;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border: 1px solid var(--theme-metal);
+  border-left: 3px solid var(--theme-accent);
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.2em;
+  padding-left: 1.65em;
+}
+
+.markdown-body li {
+  margin: 0.32em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+  font-weight: 700;
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 2.5em 0;
+  background: var(--theme-metal);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.12em 0.34em;
+  color: #003d9f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: #e2ecf8;
+  border: 1px solid #a8b8ca;
+  border-radius: 2px;
+}
+
+.markdown-body pre {
+  margin: 1.45em 0;
+  padding: 1.15em 1.2em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88rem;
+  line-height: 1.62;
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-metal);
+  border-left: 3px solid var(--theme-accent);
+  border-radius: 2px;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 1.5em 0;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-metal);
+  border-radius: 0;
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.64em 0.82em;
+  text-align: left;
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body th {
+  color: var(--theme-heading);
+  font-size: 0.84em;
+  font-weight: 760;
+  letter-spacing: 0.045em;
+  background: var(--theme-quote-surface);
+  border-bottom-color: var(--theme-metal);
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: #f7faff;
+}
+
+.markdown-body img {
+  margin: 1.5em auto;
+  border: 1px solid var(--theme-metal);
+  border-radius: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.12em 0.4em;
+  color: var(--theme-heading-on-accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82em;
+  background: var(--theme-carbon);
+  border: 1px solid var(--theme-metal);
+  border-radius: 2px;
+}
+
+.markdown-body mark {
+  padding: 0.05em 0.22em;
+  color: #061126;
+  background: #a9c9ff;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #0b0e12;
+    --theme-text: #e7edf4;
+    --theme-muted: #aeb9c5;
+    --theme-heading: #f4f8fc;
+    --theme-carbon: #0b0e12;
+    --theme-ice: #f4f8fc;
+    --theme-accent: #4385ff;
+    --theme-link: #79a8ff;
+    --theme-focus: #73a4ff;
+    --theme-metal: #647180;
+    --theme-border: #46515e;
+    --theme-quote-surface: #141a21;
+    --theme-table-surface: #10151b;
+    --theme-diagram-surface: #10151b;
+    --theme-diagram-text: #e7edf4;
+    --theme-diagram-node-surface: #162236;
+    --theme-diagram-node-border: #6d9fff;
+    --theme-diagram-line: #aeb9c5;
+    --theme-diagram-label-surface: #10151b;
+    --theme-code-text: #eff5ff;
+    --theme-code-surface: #05070a;
+    --theme-heading-on-accent: #0b0e12;
+    --theme-syntax-comment: #9aa7b6;
+    --theme-syntax-keyword: #86b2ff;
+    --theme-syntax-string: #bdd7ff;
+    --theme-syntax-number: #ffffff;
+    --theme-syntax-title: #73a4ff;
+    --theme-syntax-meta: #d5e4ff;
+  }
+
+  .markdown-body h1 {
+    color: var(--theme-heading-on-accent);
+    background: var(--theme-ice);
+  }
+
+  .markdown-body code {
+    color: #a9c9ff;
+    background: #111d31;
+    border-color: #405b82;
+  }
+
+  .markdown-body tbody tr:nth-child(even) {
+    background: #141a21;
+  }
+
+  .markdown-body mark {
+    color: #061126;
+    background: #8db8ff;
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    padding: 0.58em 0.62em;
+    font-size: clamp(2rem, 11vw, 3rem);
+  }
+
+  .theme-sampler .markdown-body h1,
+  .markdown-theme-sampler .markdown-body h1 {
+    font-size: clamp(1.4rem, 7vw, 1.9rem);
+  }
+}

--- a/public/css/markdown-bytedance.css
+++ b/public/css/markdown-bytedance.css
@@ -11,11 +11,24 @@
   --theme-focus: #0b6cf0;
   --theme-border: #cbd8e8;
   --theme-subtle-border: #dbe6f2;
-  --theme-surface: #ffffff;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #ffffff;
   --theme-soft-surface: #eef5ff;
   --theme-quote-surface: #edf9f8;
   --theme-code-surface: #10233d;
   --theme-code-text: #eef7ff;
+  --theme-heading-on-accent: #ffffff;
+  --theme-diagram-text: #29435d;
+  --theme-diagram-node-surface: #e8f3ff;
+  --theme-diagram-node-border: #1677ff;
+  --theme-diagram-line: #5f7188;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-syntax-comment: #9eb0c6;
+  --theme-syntax-keyword: #f58ac3;
+  --theme-syntax-string: #a7db78;
+  --theme-syntax-number: #d6a6ff;
+  --theme-syntax-title: #7cc7ff;
+  --theme-syntax-meta: #ffd166;
 }
 
 .markdown-body {
@@ -57,7 +70,7 @@
   width: fit-content;
   margin: 2.5em 0 1em;
   padding: 0.42em 0.9em;
-  color: #ffffff;
+  color: var(--theme-heading-on-accent);
   font-size: clamp(1.4rem, 3.4vw, 1.75rem);
   background: linear-gradient(120deg, #126ee8, #007f7b);
   border-radius: 8px 20px 8px 20px;
@@ -210,7 +223,7 @@
 .markdown-body table {
   margin: 1.5em 0;
   color: var(--theme-text);
-  background: var(--theme-surface);
+  background: var(--theme-table-surface);
   border: 1px solid var(--theme-border);
   border-radius: 9px;
 }
@@ -262,7 +275,7 @@
 
 .markdown-body .mermaid {
   color: var(--theme-text);
-  background: var(--theme-surface);
+  background: var(--theme-diagram-surface);
   border: 1px solid var(--theme-border);
 }
 
@@ -277,11 +290,18 @@
     --theme-focus: #7bb8ff;
     --theme-border: #34506d;
     --theme-subtle-border: #2b435c;
-    --theme-surface: #17263a;
+    --theme-table-surface: #17263a;
+    --theme-diagram-surface: #17263a;
     --theme-soft-surface: #1c3552;
     --theme-quote-surface: #143b3e;
     --theme-code-surface: #07111f;
     --theme-code-text: #e7f2ff;
+    --theme-heading-on-accent: #061b2d;
+    --theme-diagram-text: #d8e5f3;
+    --theme-diagram-node-surface: #1d3853;
+    --theme-diagram-node-border: #5ca4ff;
+    --theme-diagram-line: #90a8c0;
+    --theme-diagram-label-surface: #17263a;
   }
 
   .markdown-body h1 {
@@ -290,7 +310,7 @@
   }
 
   .markdown-body h2 {
-    color: #061b2d;
+    color: var(--theme-heading-on-accent);
     background: linear-gradient(120deg, #75b4ff, #57ddd5);
   }
 

--- a/public/css/markdown-bytedance.css
+++ b/public/css/markdown-bytedance.css
@@ -1,515 +1,358 @@
-/**
- * u5b57u8282u8df3u52a8u98ceu683cu4e3bu9898 - u53ccu8272u7cfbu4f18u5316u7248
- * u7279u70b9uff1au73b0u4ee3u79d1u6280u611fu3001u7b80u6d01u5927u65b9u3001u89c6u89c9u5c42u6b21u5206u660e
- * u4e3bu8272u8c03uff1au84ddu8272(#1677ff)u3001u9752u7effu8272(#05d4cd)u3001u9ed1u8272(#1d2129)u548cu767du8272
- */
+/* ByteDance 蓝绿 — QuickShare brand-inspired Markdown signature */
 
-.markdown-body {
-  font-family: 'Roboto', 'Noto Sans SC', sans-serif;
-  line-height: 1.8;
-  color: #4e5969;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
+:root {
+  --theme-reading-width: 900px;
+  --theme-text: #34445b;
+  --theme-muted: #52627a;
+  --theme-heading: #172033;
+  --theme-link: #095fba;
+  --theme-accent: #1677ff;
+  --theme-secondary: #008f8a;
+  --theme-focus: #0b6cf0;
+  --theme-border: #cbd8e8;
+  --theme-subtle-border: #dbe6f2;
+  --theme-surface: #ffffff;
+  --theme-soft-surface: #eef5ff;
+  --theme-quote-surface: #edf9f8;
+  --theme-code-surface: #10233d;
+  --theme-code-text: #eef7ff;
 }
 
-/* u4e00u7ea7u6807u9898u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
+.markdown-body {
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.75;
+  color: var(--theme-text);
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 650;
+  line-height: 1.28;
+  letter-spacing: -0.015em;
+}
+
 .markdown-body h1 {
-  display: table;
-  padding: 0.6em 1.5em;
-  margin: 2em auto 1.5em;
-  color: #1d2129;
-  font-size: 1.6em;
-  font-weight: 600;
-  text-align: center;
   position: relative;
-  background: linear-gradient(to right, rgba(22,119,255,0.02), rgba(5,212,205,0.05), rgba(22,119,255,0.02));
-  border-radius: 4px;
+  width: fit-content;
+  margin: 0 auto 1.6em;
+  padding: 0.72em 1.25em 0.66em;
+  font-size: clamp(1.9rem, 5vw, 2.65rem);
+  text-align: center;
+  background: linear-gradient(135deg, rgba(22, 119, 255, 0.08), rgba(0, 143, 138, 0.1));
+  border: 1px solid rgba(22, 119, 255, 0.18);
+  border-radius: 12px;
 }
 
 .markdown-body h1::before {
   content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, #1677ff, #05d4cd, #1677ff);
-  border-radius: 3px 3px 0 0;
+  inset: 0 0 auto;
+  height: 4px;
+  background: linear-gradient(90deg, var(--theme-accent), var(--theme-secondary));
+  border-radius: 11px 11px 0 0;
 }
 
-.markdown-body h1::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, rgba(22,119,255,0), rgba(5,212,205,0.5), rgba(22,119,255,0));
-}
-
-/* u6807u9898u88c5u9970u5143u7d20 */
-.markdown-body h1 span {
-  position: relative;
-  z-index: 1;
-}
-
-.markdown-body h1 span::before {
-  content: "";
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 100%;
-  height: 6px;
-  background: linear-gradient(90deg, rgba(22,119,255,0.1), rgba(5,212,205,0.1));
-  z-index: -1;
-}
-
-/* u4e8cu7ea7u6807u9898u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body h2 {
-  display: table;
-  padding: 0.4em 1.4em;
-  margin: 3em auto 1.5em;
-  color: #fff;
-  background: linear-gradient(135deg, #1677ff, #05d4cd);
-  font-size: 1.3em;
-  font-weight: 600;
-  text-align: center;
-  border-radius: 8px 24px 8px 24px;
-  box-shadow: 0 4px 12px rgba(5,212,205,0.15);
-  position: relative;
-  letter-spacing: 0.02em;
+  width: fit-content;
+  margin: 2.5em 0 1em;
+  padding: 0.42em 0.9em;
+  color: #ffffff;
+  font-size: clamp(1.4rem, 3.4vw, 1.75rem);
+  background: linear-gradient(120deg, #126ee8, #007f7b);
+  border-radius: 8px 20px 8px 20px;
 }
 
-.markdown-body h2::before {
-  content: "";
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  right: -2px;
-  bottom: -2px;
-  background: linear-gradient(135deg, #1677ff, #05d4cd);
-  border-radius: 10px 26px 10px 26px;
-  z-index: -1;
-  opacity: 0.3;
-  filter: blur(8px);
-}
-
-.markdown-body h2::after {
-  content: "";
-  position: absolute;
-  bottom: -8px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 8px solid #05d4cd;
-}
-
-/* u4e09u7ea7u6807u9898u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body h3 {
-  padding: 0.5em 1em 0.5em 12px;
-  font-size: 1.2em;
-  border-radius: 6px;
-  line-height: 1.6;
-  border-left: 4px solid #1677ff;
-  border-right: 1px solid rgba(22,119,255,0.1);
-  border-bottom: 1px solid rgba(22,119,255,0.1);
-  border-top: 1px solid rgba(22,119,255,0.1);
-  background: rgba(22,119,255,0.05);
-  color: #1677ff;
-  margin: 2em 0 0.75em;
-  font-weight: 600;
-  position: relative;
+  margin: 2.1em 0 0.8em;
+  padding: 0.5em 0.75em;
+  color: #0d62bf;
+  font-size: 1.25rem;
+  background: rgba(22, 119, 255, 0.06);
+  border: 1px solid rgba(22, 119, 255, 0.18);
+  border-left: 4px solid var(--theme-accent);
+  border-radius: 7px;
 }
 
-.markdown-body h3::after {
-  content: "";
-  position: absolute;
-  bottom: -1px;
-  right: -1px;
-  width: 8px;
-  height: 8px;
-  border-radius: 0 0 6px 0;
-  background: #05d4cd;
-  opacity: 0.4;
-}
-
-/* u56dbu7ea7u6807u9898u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body h4 {
-  margin: 2em 0 0.5em;
-  color: #05d4cd;
-  font-size: 1.1em;
-  font-weight: 500;
-  border-radius: 6px;
-  padding: 0.3em 0 0.3em 0.6em;
-  border-bottom: 1px dashed rgba(5,212,205,0.3);
-  position: relative;
+  margin: 1.8em 0 0.65em;
+  padding-bottom: 0.3em;
+  color: #08736f;
+  font-size: 1.08rem;
+  border-bottom: 1px dashed rgba(0, 143, 138, 0.42);
 }
 
-.markdown-body h4::before {
-  content: "u25c6";
-  color: #05d4cd;
-  font-size: 0.8em;
-  margin-right: 8px;
-  opacity: 0.6;
+.markdown-body :where(h5, h6) {
+  margin: 1.5em 0 0.55em;
 }
 
-/* u6bb5u843du6837u5f0f */
+.markdown-body h6 {
+  color: var(--theme-muted);
+}
+
 .markdown-body p {
-  margin: 1.5em 0;
-  letter-spacing: 0;
-  color: #4e5969;
-  text-align: justify;
-  line-height: 1.8;
-  font-size: 15px;
+  margin: 0 0 1.2em;
 }
 
-/* u5f15u7528u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
+.markdown-body a {
+  font-weight: 550;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
+}
+
+.markdown-body a:hover {
+  color: #064f9c;
+  text-decoration-color: currentColor;
+}
+
+.markdown-body :where(strong, b) {
+  color: #0d62bf;
+  font-weight: 700;
+}
+
+.markdown-body :where(em, i) {
+  color: #08736f;
+}
+
 .markdown-body blockquote {
-  font-style: normal;
-  padding: 1em 1em 1em 2em;
-  border-left: 4px solid #05d4cd;
-  border-radius: 6px;
-  color: #4e5969;
-  background: #f2f3f5;
-  margin: 1.5em 0;
-  border-bottom: 0.2px solid rgba(5,212,205,0.1);
-  border-top: 0.2px solid rgba(5,212,205,0.1);
-  border-right: 0.2px solid rgba(5,212,205,0.1);
   position: relative;
+  margin: 1.5em 0;
+  padding: 1em 1.15em 1em 1.6em;
+  color: #3b5566;
+  background: var(--theme-quote-surface);
+  border: 1px solid rgba(0, 143, 138, 0.2);
+  border-left: 4px solid var(--theme-secondary);
+  border-radius: 8px;
 }
 
 .markdown-body blockquote::before {
-  content: "u201c";
+  content: "“";
   position: absolute;
-  left: 8px;
-  top: 8px;
-  font-size: 2em;
-  color: rgba(5,212,205,0.2);
+  top: 0.14em;
+  left: 0.38em;
+  color: rgba(0, 143, 138, 0.38);
   font-family: Georgia, serif;
+  font-size: 2rem;
+  line-height: 1;
 }
 
-/* u7c97u4f53u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body strong {
-  color: #1677ff;
-  font-weight: 600;
-  font-size: inherit;
-  padding: 0 2px;
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
 }
 
-/* u659cu4f53u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body em {
-  color: #05d4cd;
-  font-style: italic;
-  font-size: inherit;
-}
-
-/* u5206u5272u7ebfu6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body hr {
-  height: 1px;
-  border: none;
-  margin: 2.5em 0;
-  background: linear-gradient(to right, rgba(22,119,255,0), rgba(5,212,205,0.5), rgba(22,119,255,0));
-  position: relative;
-}
-
-.markdown-body hr::before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 6px;
-  height: 6px;
-  background: #05d4cd;
-  border-radius: 50%;
-  box-shadow: -20px 0 0 rgba(22,119,255,0.5), 20px 0 0 rgba(22,119,255,0.5);
-}
-
-/* u5217u8868u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body ul {
-  list-style: none;
-  padding-left: 1.5em;
-  margin: 1.5em 0;
-  color: #4e5969;
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.2em;
+  padding-left: 1.7em;
 }
 
 .markdown-body li {
-  position: relative;
-  margin: 0.5em 0;
-  padding-left: 1em;
-  line-height: 1.6;
+  margin: 0.35em 0;
+  padding-left: 0.2em;
 }
 
-.markdown-body ul li::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.7em;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #1677ff;
+.markdown-body ul li::marker {
+  color: var(--theme-secondary);
 }
 
-/* u5076u6570u5217u8868u9879u4f7fu7528u9752u7effu8272 */
-.markdown-body ul li:nth-child(even)::before {
-  background: #05d4cd;
+.markdown-body ol li::marker {
+  color: var(--theme-accent);
+  font-weight: 700;
 }
 
-/* u6709u5e8fu5217u8868 */
-.markdown-body ol {
-  padding-left: 1.5em;
-  margin: 1.5em 0;
-  color: #4e5969;
-  counter-reset: item;
+.markdown-body hr {
+  height: 2px;
+  margin: 2.5em 0;
+  background: linear-gradient(90deg, transparent, var(--theme-accent), var(--theme-secondary), transparent);
+  border: 0;
 }
 
-.markdown-body ol li {
-  position: relative;
-  margin: 0.5em 0;
-  padding-left: 0.5em;
-  line-height: 1.6;
+.markdown-body code {
+  padding: 0.14em 0.38em;
+  color: #094d8f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: var(--theme-soft-surface);
+  border: 1px solid rgba(22, 119, 255, 0.14);
+  border-radius: 5px;
 }
 
-/* u4ee3u7801u5757u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body pre {
-  font-size: 14px;
-  overflow-x: auto;
-  border-radius: 8px;
-  padding: 1em;
-  line-height: 1.5;
-  margin: 1.5em 0;
-  border: 1px solid rgba(5,212,205,0.1);
-  background: #f7f8fa;
   position: relative;
+  margin: 1.45em 0;
+  padding: 1.2em 1.25em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  background: var(--theme-code-surface);
+  border: 1px solid #294765;
+  border-top: 4px solid var(--theme-accent);
+  border-radius: 10px;
 }
 
 .markdown-body pre::before {
   content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  inset: -4px 0 auto 55%;
   height: 4px;
-  background: linear-gradient(to right, #1677ff, #05d4cd);
-  border-radius: 4px 4px 0 0;
-}
-
-/* u884cu5185u4ee3u7801u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body code {
-  font-size: 90%;
-  color: #05d4cd;
-  background: rgba(5,212,205,0.1);
-  padding: 3px 5px;
-  border-radius: 4px;
-  font-family: "SFMono-Regular", Consolas, Menlo, monospace;
+  background: var(--theme-secondary);
+  border-radius: 0 9px 0 0;
 }
 
 .markdown-body pre code {
-  background: transparent;
   padding: 0;
   color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
 }
 
-/* u94feu63a5u6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
-.markdown-body a {
-  color: #1677ff;
-  text-decoration: none;
-  border-bottom: 1px solid rgba(22,119,255,0.3);
-  transition: all 0.2s ease;
-}
-
-.markdown-body a:hover {
-  color: #05d4cd;
-  border-bottom-color: #05d4cd;
-}
-
-/* u56feu7247u6837u5f0f */
-.markdown-body img {
-  max-width: 100%;
-  border-radius: 8px;
-  margin: 1.5em auto;
-  display: block;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  border: 1px solid rgba(5,212,205,0.1);
-}
-
-/* u8868u683cu6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body table {
-  width: 100%;
-  border-collapse: collapse;
   margin: 1.5em 0;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  color: var(--theme-text);
+  background: var(--theme-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 9px;
 }
 
-.markdown-body thead {
-  background: linear-gradient(to right, rgba(22,119,255,0.05), rgba(5,212,205,0.05));
+.markdown-body :where(th, td) {
+  padding: 0.7em 0.95em;
+  text-align: left;
+  border: 1px solid var(--theme-subtle-border);
 }
 
 .markdown-body th {
-  padding: 12px 16px;
-  text-align: left;
-  font-weight: 600;
-  color: #1677ff;
-  border-bottom: 1px solid rgba(5,212,205,0.1);
+  color: #16466f;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(22, 119, 255, 0.1), rgba(0, 143, 138, 0.1));
 }
 
-.markdown-body th:nth-child(even) {
-  color: #05d4cd;
+.markdown-body tbody tr:nth-child(even) {
+  background: rgba(22, 119, 255, 0.035);
 }
 
-.markdown-body td {
-  padding: 10px 16px;
-  border-bottom: 1px solid rgba(0,0,0,0.05);
-  color: #4e5969;
+.markdown-body img {
+  margin: 1.5em auto;
+  border: 1px solid var(--theme-border);
+  border-radius: 10px;
 }
 
-.markdown-body tr:last-child td {
-  border-bottom: none;
-}
-
-.markdown-body tr:nth-child(even) {
-  background: rgba(247,248,250,0.7);
-}
-
-/* u952eu76d8u6837u5f0f */
 .markdown-body kbd {
-  background: #f7f8fa;
-  border: 1px solid #d9d9d9;
-  border-radius: 4px;
-  box-shadow: 0 2px 0 rgba(0,0,0,0.05);
-  color: #4e5969;
   display: inline-block;
-  font-size: 0.85em;
-  line-height: 1;
-  padding: 2px 5px;
-  margin: 0 2px;
+  padding: 0.16em 0.45em;
+  color: #233a54;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82em;
+  background: #f7fbff;
+  border: 1px solid #b9c9db;
+  border-bottom-width: 2px;
+  border-radius: 5px;
 }
 
-/* u6807u8bb0/u9ad8u4eaeu6837u5f0f - u53ccu8272u7cfbu4f18u5316 */
 .markdown-body mark {
-  background: linear-gradient(120deg, rgba(22,119,255,0.1), rgba(5,212,205,0.1));
-  color: #1d2129;
-  padding: 0 4px;
-  border-radius: 2px;
+  padding: 0.08em 0.25em;
+  color: #17304d;
+  background: #d8f5f1;
+  border-radius: 3px;
 }
 
-/* u6309u94aeu6837u5f0f */
-.markdown-body .button {
-  display: inline-block;
-  padding: 8px 16px;
-  background: linear-gradient(135deg, #1677ff, #05d4cd);
-  color: white;
-  border-radius: 4px;
-  font-weight: 500;
-  text-align: center;
-  transition: all 0.3s ease;
-  border: none;
-  box-shadow: 0 2px 6px rgba(5,212,205,0.2);
-  cursor: pointer;
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
 }
 
-.markdown-body .button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(22,119,255,0.3);
+.markdown-body .mermaid {
+  color: var(--theme-text);
+  background: var(--theme-surface);
+  border: 1px solid var(--theme-border);
 }
 
-/* u5361u7247u6837u5f0f */
-.markdown-body .card {
-  background: white;
-  border-radius: 8px;
-  padding: 16px;
-  margin: 16px 0;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-  border-top: 3px solid;
-  border-image: linear-gradient(to right, #1677ff, #05d4cd) 1;
-}
-
-/* u63d0u793au6846u6837u5f0f */
-.markdown-body .tip {
-  background: rgba(5,212,205,0.05);
-  border-left: 4px solid #05d4cd;
-  padding: 12px 16px;
-  margin: 16px 0;
-  border-radius: 0 4px 4px 0;
-  color: #4e5969;
-}
-
-.markdown-body .warning {
-  background: rgba(255,152,0,0.05);
-  border-left: 4px solid #ff9800;
-  padding: 12px 16px;
-  margin: 16px 0;
-  border-radius: 0 4px 4px 0;
-  color: #4e5969;
-}
-
-/* u6697u8272u6a21u5f0fu9002u914d */
 @media (prefers-color-scheme: dark) {
-  .markdown-body {
-    color: #e6e6e6;
-    background-color: #1a1a1a;
+  :root {
+    --theme-text: #d8e5f3;
+    --theme-muted: #9fb0c5;
+    --theme-heading: #f3f8ff;
+    --theme-link: #78b7ff;
+    --theme-accent: #5ca4ff;
+    --theme-secondary: #4fe1d8;
+    --theme-focus: #7bb8ff;
+    --theme-border: #34506d;
+    --theme-subtle-border: #2b435c;
+    --theme-surface: #17263a;
+    --theme-soft-surface: #1c3552;
+    --theme-quote-surface: #143b3e;
+    --theme-code-surface: #07111f;
+    --theme-code-text: #e7f2ff;
   }
-  
+
   .markdown-body h1 {
-    color: #f5f5f7;
-    background: linear-gradient(to right, rgba(22,119,255,0.05), rgba(5,212,205,0.08), rgba(22,119,255,0.05));
+    background: linear-gradient(135deg, rgba(92, 164, 255, 0.14), rgba(79, 225, 216, 0.12));
+    border-color: rgba(92, 164, 255, 0.34);
   }
-  
-  .markdown-body p {
-    color: #e6e6e6;
+
+  .markdown-body h2 {
+    color: #061b2d;
+    background: linear-gradient(120deg, #75b4ff, #57ddd5);
   }
-  
+
+  .markdown-body h3 {
+    color: #a9d0ff;
+    background: rgba(92, 164, 255, 0.1);
+    border-color: rgba(92, 164, 255, 0.3);
+    border-left-color: var(--theme-accent);
+  }
+
+  .markdown-body h4,
+  .markdown-body :where(em, i) {
+    color: #7ce5de;
+  }
+
+  .markdown-body :where(strong, b) {
+    color: #9cc9ff;
+  }
+
+  .markdown-body a:hover {
+    color: #a9d0ff;
+  }
+
   .markdown-body blockquote {
-    background: #2a2a2a;
-    color: #e6e6e6;
-    border-left: 4px solid #05d4cd;
+    color: #c5d8e5;
+    border-color: rgba(79, 225, 216, 0.28);
+    border-left-color: var(--theme-secondary);
   }
-  
-  .markdown-body pre {
-    background: #282c34;
-    border-color: rgba(5,212,205,0.2);
-  }
-  
+
   .markdown-body code {
-    background: rgba(5,212,205,0.15);
+    color: #b9dcff;
+    border-color: rgba(92, 164, 255, 0.25);
   }
-  
-  .markdown-body table {
-    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+
+  .markdown-body th {
+    color: #dcecff;
+    background: linear-gradient(135deg, rgba(92, 164, 255, 0.18), rgba(79, 225, 216, 0.15));
   }
-  
-  .markdown-body thead {
-    background: linear-gradient(to right, rgba(22,119,255,0.1), rgba(5,212,205,0.1));
+
+  .markdown-body tbody tr:nth-child(even) {
+    background: rgba(92, 164, 255, 0.05);
   }
-  
-  .markdown-body td {
-    border-bottom-color: rgba(255,255,255,0.05);
-    color: #e6e6e6;
-  }
-  
-  .markdown-body tr:nth-child(even) {
-    background: rgba(40,40,40,0.7);
-  }
-  
-  .markdown-body .card {
-    background: #2a2a2a;
-  }
-  
+
   .markdown-body kbd {
-    background: #2a2a2a;
-    border-color: #444;
-    color: #e6e6e6;
+    color: #dcecff;
+    background: #20364f;
+    border-color: #54708d;
   }
-  
-  .markdown-body ul li, 
-  .markdown-body ol li {
-    color: #e6e6e6;
+
+  .markdown-body mark {
+    color: #dffaf7;
+    background: #245b59;
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    width: 100%;
+    padding-inline: 0.8em;
+  }
+
+  .markdown-body h2 {
+    border-radius: 8px 16px 8px 16px;
   }
 }

--- a/public/css/markdown-claude.css
+++ b/public/css/markdown-claude.css
@@ -1,193 +1,231 @@
-/* ===== Claude Warm Editorial Markdown 主题 ===== */
-
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap');
-
-.markdown-body {
-  font-family: 'Inter', 'StyreneB', system-ui, -apple-system, sans-serif;
-  font-size: 16px;
-  line-height: 1.55;
-  color: #3d3d3a;
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 32px 24px;
-  word-wrap: break-word;
-  background-color: #faf9f5;
+/* Claude 暖调 signature: warm editorial paper, system serif, and terracotta. */
+:root {
+  --theme-canvas: #faf7f2;
+  --theme-text: #3d392f;
+  --theme-muted: #686056;
+  --theme-accent: #984b32;
+  --theme-link: #984b32;
+  --theme-border: #d8cfc3;
+  --theme-quote-surface: #f2e9dd;
+  --theme-table-surface: #fffaf4;
+  --theme-diagram-surface: #f7efe5;
+  --theme-code-text: #f8f4ed;
+  --theme-code-surface: #211f1c;
+  --theme-focus: #8c3f2c;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-diagram-text: #3d392f;
+  --theme-diagram-node-surface: #f0e4d7;
+  --theme-diagram-node-border: #984b32;
+  --theme-diagram-line: #686056;
+  --theme-diagram-label-surface: #fffaf4;
+  --theme-syntax-comment: #bcb3a8;
+  --theme-syntax-keyword: #f0a581;
+  --theme-syntax-string: #a9d6a2;
+  --theme-syntax-number: #f3c67a;
+  --theme-syntax-title: #9fc8e8;
+  --theme-syntax-meta: #d5b5e8;
+  --theme-reading-width: 800px;
+  --claude-heading-font: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --claude-inline-code: #713d2c;
+  --claude-inline-code-surface: #efe5d8;
+  --claude-row-alt: #f5ede3;
+  --claude-mark-surface: #984b32;
+  --claude-mark-text: #ffffff;
 }
 
-/* ===== Headings — serif display ===== */
-.markdown-body h1, .markdown-body h2, .markdown-body h3,
-.markdown-body h4, .markdown-body h5, .markdown-body h6 {
-  font-family: Georgia, 'Copernicus', 'Tiempos Headline', serif;
-  color: #141413;
-  line-height: 1.15;
+.markdown-body {
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-text);
+  font-family: var(--claude-heading-font);
   font-weight: 400;
-  letter-spacing: -0.3px;
+  line-height: 1.16;
+  letter-spacing: -0.015em;
 }
 
 .markdown-body h1 {
-  font-size: 2.25em;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  letter-spacing: -1px;
+  margin-block: 1.2em 0.5em;
   padding-bottom: 0.4em;
-  border-bottom: 2px solid #e6dfd8;
+  font-size: 2.25em;
+  letter-spacing: -0.03em;
+  border-bottom: 2px solid var(--theme-border);
 }
 
 .markdown-body h2 {
-  font-size: 1.6em;
-  margin-top: 1.5em;
-  margin-bottom: 0.4em;
-  letter-spacing: -0.5px;
+  margin-block: 1.5em 0.4em;
   padding-bottom: 0.3em;
-  border-bottom: 1px solid #ebe6df;
+  font-size: 1.6em;
+  border-bottom: 1px solid var(--theme-border);
 }
 
 .markdown-body h3 {
+  margin-block: 1.3em 0.4em;
   font-size: 1.3em;
-  margin-top: 1.3em;
-  margin-bottom: 0.4em;
 }
 
-.markdown-body h4 { font-size: 1.1em; margin-top: 1.2em; margin-bottom: 0.3em; }
-.markdown-body h5 { font-size: 1em; margin-top: 1em; margin-bottom: 0.3em; font-weight: 500; }
-.markdown-body h6 { font-size: 0.9em; margin-top: 1em; margin-bottom: 0.3em; font-weight: 500; color: #6c6a64; }
+.markdown-body h4 { margin-block: 1.2em 0.3em; font-size: 1.1em; }
+.markdown-body h5 { margin-block: 1em 0.3em; font-size: 1em; font-weight: 600; }
+.markdown-body h6 { margin-block: 1em 0.3em; color: var(--theme-muted); font-size: 0.9em; font-weight: 600; }
 
-/* ===== Body text ===== */
 .markdown-body p {
-  margin-top: 0;
-  margin-bottom: 1em;
+  margin-block: 0 1em;
 }
 
-.markdown-body strong { font-weight: 600; color: #141413; }
-.markdown-body em { font-style: italic; }
+.markdown-body strong {
+  color: var(--theme-text);
+  font-weight: 650;
+}
 
-/* ===== Links — coral ===== */
 .markdown-body a {
-  color: #cc785c;
+  color: var(--theme-link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-  transition: color 0.15s ease;
+  text-underline-offset: 0.18em;
 }
 
 .markdown-body a:hover {
-  color: #a9583e;
+  text-decoration-thickness: 2px;
 }
 
-/* ===== Blockquote ===== */
 .markdown-body blockquote {
-  margin: 0 0 1em 0;
-  padding: 0.75em 1em;
-  color: #6c6a64;
-  border-left: 3px solid #cc785c;
-  background-color: #f5f0e8;
+  margin: 0 0 1em;
+  padding: 0.8em 1em;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border-left: 3px solid var(--theme-accent);
   border-radius: 0 6px 6px 0;
 }
 
-.markdown-body blockquote p:last-child { margin-bottom: 0; }
+.markdown-body blockquote p:last-child {
+  margin-bottom: 0;
+}
 
-/* ===== Code — dark surface ===== */
 .markdown-body code {
-  padding: 0.15em 0.4em;
-  margin: 0;
-  font-size: 87%;
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
-  background-color: #efe9de;
+  padding: 0.14em 0.38em;
+  color: var(--claude-inline-code);
+  background: var(--claude-inline-code-surface);
   border-radius: 4px;
-  color: #141413;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 87%;
 }
 
 .markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 1em;
+  margin-block: 0 1em;
   padding: 1em 1.25em;
-  overflow: auto;
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 14px;
   line-height: 1.6;
-  background-color: #181715;
-  color: #faf9f5;
-  border-radius: 8px;
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .markdown-body pre code {
   padding: 0;
-  margin: 0;
-  font-size: 100%;
-  white-space: pre;
+  color: inherit;
   background: transparent;
   border-radius: 0;
-  color: inherit;
+  font-size: 100%;
 }
 
-/* ===== Tables ===== */
 .markdown-body table {
-  display: block;
-  width: 100%;
-  max-width: 100%;
-  overflow: auto;
-  border-collapse: collapse;
   margin-bottom: 1em;
+  border-radius: 6px;
   font-size: 14px;
 }
 
-.markdown-body th, .markdown-body td {
-  padding: 10px 14px;
-  border: 1px solid #e6dfd8;
+.markdown-body :where(th, td) {
+  padding: 0.625em 0.875em;
 }
 
 .markdown-body th {
+  color: var(--theme-text);
+  background: var(--theme-quote-surface);
   font-weight: 600;
-  color: #141413;
-  background-color: #f5f0e8;
 }
 
-.markdown-body tr { background-color: #faf9f5; }
-.markdown-body tr:nth-child(even) { background-color: #f5f0e8; }
+.markdown-body tr:nth-child(even) {
+  background: var(--claude-row-alt);
+}
 
-/* ===== Lists ===== */
-.markdown-body ul, .markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 1em;
+.markdown-body :where(ul, ol) {
+  margin-block: 0 1em;
   padding-left: 2em;
 }
 
-.markdown-body li { margin-bottom: 0.3em; }
-.markdown-body li + li { margin-top: 0.3em; }
+.markdown-body li {
+  margin-bottom: 0.3em;
+}
 
-/* ===== HR ===== */
+.markdown-body li + li {
+  margin-top: 0.3em;
+}
+
 .markdown-body hr {
   height: 1px;
-  padding: 0;
   margin: 2em 0;
-  background-color: #e6dfd8;
+  background: var(--theme-border);
   border: 0;
 }
 
-/* ===== Images ===== */
 .markdown-body img {
-  max-width: 100%;
   border-radius: 8px;
 }
 
-/* ===== Kbd ===== */
 .markdown-body kbd {
   display: inline-block;
-  padding: 3px 6px;
-  font-size: 12px;
-  line-height: 1.4;
-  color: #141413;
-  vertical-align: middle;
-  background-color: #efe9de;
-  border: 1px solid #e6dfd8;
+  padding: 0.2em 0.45em;
+  color: var(--theme-text);
+  background: var(--claude-inline-code-surface);
+  border: 1px solid var(--theme-border);
   border-radius: 4px;
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75em;
+  line-height: 1.4;
 }
 
-/* ===== Inline mark / highlight ===== */
 .markdown-body mark {
-  background-color: #cc785c;
-  color: #faf9f5;
   padding: 0.1em 0.3em;
+  color: var(--claude-mark-text);
+  background: var(--claude-mark-surface);
   border-radius: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #211e1a;
+    --theme-text: #f1e8dc;
+    --theme-muted: #c1b3a4;
+    --theme-accent: #e39a79;
+    --theme-link: #e39a79;
+    --theme-border: #5c4e44;
+    --theme-quote-surface: #302821;
+    --theme-table-surface: #28231f;
+    --theme-diagram-surface: #2c2621;
+    --theme-code-text: #f6eee3;
+    --theme-code-surface: #151311;
+    --theme-focus: #ffad88;
+    --theme-heading-on-accent: #211e1a;
+    --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+    --theme-diagram-text: #f1e8dc;
+    --theme-diagram-node-surface: #3a3028;
+    --theme-diagram-node-border: #e39a79;
+    --theme-diagram-line: #c1b3a4;
+    --theme-diagram-label-surface: #28231f;
+    --theme-syntax-comment: #bdb4aa;
+    --theme-syntax-keyword: #f0a581;
+    --theme-syntax-string: #a9d6a2;
+    --theme-syntax-number: #f3c67a;
+    --theme-syntax-title: #9fc8e8;
+    --theme-syntax-meta: #d5b5e8;
+    --theme-reading-width: 800px;
+    --claude-heading-font: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+    --claude-inline-code: #f0b79d;
+    --claude-inline-code-surface: #3a2b24;
+    --claude-row-alt: #302923;
+    --claude-mark-surface: #e39a79;
+    --claude-mark-text: #211e1a;
+  }
 }

--- a/public/css/markdown-github.css
+++ b/public/css/markdown-github.css
@@ -1,137 +1,229 @@
-/* ===== GitHub 经典 Markdown 主题 ===== */
+/* GitHub 经典 — QuickShare brand-inspired Markdown signature */
+
+:root {
+  --theme-canvas: #ffffff;
+  --theme-text: #1f2328;
+  --theme-muted: #59636e;
+  --theme-accent: #0969da;
+  --theme-link: #0969da;
+  --theme-border: #d0d7de;
+  --theme-quote-surface: #ffffff;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #f6f8fa;
+  --theme-code-text: #24292f;
+  --theme-code-surface: #f6f8fa;
+  --theme-focus: #0969da;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Helvetica, Arial, sans-serif;
+  --theme-diagram-text: #24292f;
+  --theme-diagram-node-surface: #ffffff;
+  --theme-diagram-node-border: #57606a;
+  --theme-diagram-line: #57606a;
+  --theme-diagram-label-surface: #f6f8fa;
+  --theme-reading-width: 900px;
+  --theme-syntax-comment: #59636e;
+  --theme-syntax-keyword: #cf222e;
+  --theme-syntax-string: #116329;
+  --theme-syntax-number: #0550ae;
+  --theme-syntax-title: #8250df;
+  --theme-syntax-meta: #953800;
+}
+
 .markdown-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Noto Sans, Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.6;
-  color: #1f2328;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
-  word-wrap: break-word;
 }
 
-.markdown-body h1, .markdown-body h2, .markdown-body h3,
-.markdown-body h4, .markdown-body h5, .markdown-body h6 {
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
   margin-top: 1.5em;
   margin-bottom: 0.5em;
+  color: var(--theme-text);
   font-weight: 600;
   line-height: 1.25;
-  color: #1f2328;
 }
 
-.markdown-body h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid #d0d7de; }
-.markdown-body h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid #d0d7de; }
-.markdown-body h3 { font-size: 1.25em; }
-.markdown-body h4 { font-size: 1em; }
+.markdown-body :where(h1, h2) {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--theme-border);
+}
 
-.markdown-body p { margin-top: 0; margin-bottom: 1em; }
+.markdown-body h1 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+.markdown-body h2 {
+  font-size: 1.5rem;
+}
+
+.markdown-body h3 {
+  font-size: 1.25rem;
+}
+
+.markdown-body h4 {
+  font-size: 1rem;
+}
+
+.markdown-body :where(h5, h6) {
+  font-size: 0.875rem;
+}
+
+.markdown-body p {
+  margin: 0 0 1em;
+}
+
+.markdown-body a {
+  color: var(--theme-link);
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-text);
+  font-weight: 600;
+}
 
 .markdown-body blockquote {
-  margin: 0 0 1em 0;
+  margin: 0 0 1em;
   padding: 0 1em;
-  color: #656d76;
-  border-left: 0.25em solid #d0d7de;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border-left: 0.25em solid var(--theme-border);
 }
 
-.markdown-body strong { font-weight: 600; color: #1f2328; }
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
 
-.markdown-body em { font-style: italic; }
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1em;
+  padding-left: 2em;
+}
 
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 1em;
-  padding: 1em;
-  overflow: auto;
-  font-size: 14px;
-  line-height: 1.5;
-  color: #24292f;
-  background-color: #f6f8fa;
-  border-radius: 6px;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+.markdown-body li {
+  margin: 0.25em 0;
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 1.5em 0;
+  background: var(--theme-border);
+  border: 0;
 }
 
 .markdown-body code {
   padding: 0.2em 0.4em;
-  margin: 0;
-  font-size: 85%;
-  white-space: break-spaces;
-  background-color: rgba(175, 184, 193, 0.2);
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.85em;
+  background: var(--theme-code-surface);
   border-radius: 3px;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+}
+
+.markdown-body pre {
+  margin: 0 0 1em;
+  padding: 1em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 6px;
 }
 
 .markdown-body pre code {
   padding: 0;
-  margin: 0;
-  font-size: 100%;
-  white-space: pre;
+  color: inherit;
+  font-size: inherit;
   background: transparent;
-  border-radius: 0;
-}
-
-.markdown-body a {
-  color: #0969da;
-  text-decoration: none;
-}
-
-.markdown-body a:hover { text-decoration: underline; }
-
-.markdown-body img {
-  max-width: 100%;
-  box-sizing: content-box;
-  border-radius: 6px;
+  border: 0;
 }
 
 .markdown-body table {
-  display: block;
-  width: 100%;
-  width: max-content;
-  max-width: 100%;
-  overflow: auto;
-  border-collapse: collapse;
-  margin-bottom: 1em;
+  margin: 0 0 1em;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 6px;
 }
 
-.markdown-body th, .markdown-body td {
+.markdown-body :where(th, td) {
   padding: 6px 13px;
-  border: 1px solid #d0d7de;
+  text-align: left;
+  border: 1px solid var(--theme-border);
 }
 
 .markdown-body th {
   font-weight: 600;
-  background-color: #f6f8fa;
+  background: var(--theme-code-surface);
 }
 
-.markdown-body tr { background-color: #ffffff; }
-.markdown-body tr:nth-child(even) { background-color: #f6f8fa; }
-
-.markdown-body hr {
-  height: 1px;
-  padding: 0;
-  margin: 1.5em 0;
-  background-color: #d0d7de;
-  border: 0;
+.markdown-body tbody tr:nth-child(even) {
+  background: var(--theme-code-surface);
 }
 
-.markdown-body ul, .markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 1em;
-  padding-left: 2em;
+.markdown-body img {
+  margin: 1em auto;
+  border-radius: 6px;
 }
-
-.markdown-body li { margin-bottom: 0.25em; }
-.markdown-body li + li { margin-top: 0.25em; }
 
 .markdown-body kbd {
   display: inline-block;
   padding: 3px 5px;
-  font-size: 11px;
-  line-height: 10px;
-  color: #1f2328;
+  color: var(--theme-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.75rem;
+  line-height: 1;
   vertical-align: middle;
-  background-color: #f6f8fa;
-  border: 1px solid rgba(175, 184, 193, 0.2);
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-border);
   border-radius: 6px;
-  box-shadow: inset 0 -1px 0 rgba(175, 184, 193, 0.2);
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+}
+
+.markdown-body mark {
+  padding: 0.1em 0.25em;
+  color: var(--theme-text);
+  background: #fff8c5;
+  border-radius: 3px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+.markdown-body .mermaid {
+  border-radius: 6px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #0d1117;
+    --theme-text: #e6edf3;
+    --theme-muted: #9da7b3;
+    --theme-accent: #58a6ff;
+    --theme-link: #58a6ff;
+    --theme-border: #30363d;
+    --theme-quote-surface: #0d1117;
+    --theme-table-surface: #0d1117;
+    --theme-diagram-surface: #161b22;
+    --theme-code-text: #e6edf3;
+    --theme-code-surface: #161b22;
+    --theme-focus: #58a6ff;
+    --theme-heading-on-accent: #0d1117;
+    --theme-diagram-text: #e6edf3;
+    --theme-diagram-node-surface: #0d1117;
+    --theme-diagram-node-border: #8b949e;
+    --theme-diagram-line: #8b949e;
+    --theme-diagram-label-surface: #161b22;
+    --theme-syntax-comment: #9da7b3;
+    --theme-syntax-keyword: #ff7b72;
+    --theme-syntax-string: #7ee787;
+    --theme-syntax-number: #79c0ff;
+    --theme-syntax-title: #d2a8ff;
+    --theme-syntax-meta: #ffa657;
+  }
+
+  .markdown-body mark {
+    color: #f0f6fc;
+    background: #6e5c00;
+  }
 }

--- a/public/css/markdown-github.css
+++ b/public/css/markdown-github.css
@@ -44,6 +44,7 @@
   overflow: auto;
   font-size: 14px;
   line-height: 1.5;
+  color: #24292f;
   background-color: #f6f8fa;
   border-radius: 6px;
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;

--- a/public/css/markdown-google.css
+++ b/public/css/markdown-google.css
@@ -1,0 +1,294 @@
+/* Google Material — tonal, reading-first Markdown signature */
+
+:root {
+  --theme-canvas: #f8fafd;
+  --theme-text: #1f1f1f;
+  --theme-muted: #5f6368;
+  --theme-heading: #1f1f1f;
+  --theme-link: #0b57d0;
+  --theme-accent: #0b57d0;
+  --theme-secondary: #725c00;
+  --theme-focus: #0b57d0;
+  --theme-border: #a9bad2;
+  --theme-tonal-surface: #e8f0fe;
+  --theme-soft-surface: #eef3fb;
+  --theme-quote-text: #3c4043;
+  --theme-quote-surface: #e9eef6;
+  --theme-table-surface: #ffffff;
+  --theme-table-heading: #1f1f1f;
+  --theme-table-heading-surface: #e8f0fe;
+  --theme-code-text: #e7edf7;
+  --theme-code-surface: #172033;
+  --theme-heading-on-accent: #ffffff;
+  --theme-diagram-text: #1f1f1f;
+  --theme-diagram-surface: #f0f4fa;
+  --theme-diagram-node-surface: #e2ebf8;
+  --theme-diagram-node-border: #0b57d0;
+  --theme-diagram-line: #5f6f83;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-syntax-comment: #b8c3d4;
+  --theme-syntax-keyword: #f4a6c1;
+  --theme-syntax-string: #9bd37a;
+  --theme-syntax-number: #c7a8ff;
+  --theme-syntax-title: #8fc8ff;
+  --theme-syntax-meta: #f5ce73;
+  --theme-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-reading-width: 880px;
+}
+
+.markdown-body {
+  font-family: var(--theme-font-family);
+  font-size: 16px;
+  line-height: 1.72;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.018em;
+}
+
+.markdown-body h1 {
+  margin: 0 0 1.3em;
+  padding: 0.72em 0.9em;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  background: var(--theme-tonal-surface);
+  border: 1px solid #c1d3ee;
+  border-radius: 28px 8px 28px 8px;
+}
+
+.markdown-body h2 {
+  position: relative;
+  margin: 2.2em 0 0.85em;
+  padding: 0.55em 2.1em 0.55em 0.8em;
+  font-size: clamp(1.45rem, 3.2vw, 1.8rem);
+  background: var(--theme-soft-surface);
+  border-radius: 8px 22px 8px 22px;
+}
+
+.markdown-body h2::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0.85em;
+  width: 0.48em;
+  height: 0.48em;
+  background: var(--theme-secondary);
+  border-radius: 3px 9px 3px 9px;
+  transform: translateY(-50%);
+}
+
+.markdown-body h3 {
+  margin: 1.9em 0 0.7em;
+  padding-left: 0.7em;
+  color: #084ba8;
+  font-size: 1.25rem;
+  border-left: 4px solid var(--theme-accent);
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.6em 0 0.55em;
+}
+
+.markdown-body h4 {
+  font-size: 1.08rem;
+}
+
+.markdown-body :where(h5, h6) {
+  color: var(--theme-muted);
+  font-size: 0.96rem;
+}
+
+.markdown-body p {
+  margin: 0 0 1.15em;
+}
+
+.markdown-body a {
+  font-weight: 550;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-heading);
+  font-weight: 700;
+}
+
+.markdown-body blockquote {
+  margin: 1.4em 0;
+  padding: 1em 1.15em;
+  color: var(--theme-quote-text);
+  background: var(--theme-quote-surface);
+  border: 0;
+  border-left: 5px solid var(--theme-accent);
+  border-radius: 6px 20px 20px 6px;
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.15em;
+  padding-left: 1.7em;
+}
+
+.markdown-body li {
+  margin: 0.32em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 2.4em 0;
+  background: var(--theme-border);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.15em 0.4em;
+  color: #17406f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: var(--theme-tonal-surface);
+  border-radius: 6px 2px 6px 2px;
+}
+
+.markdown-body pre {
+  margin: 1.4em 0;
+  padding: 1.15em 1.25em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  background: var(--theme-code-surface);
+  border: 1px solid #35465e;
+  border-radius: 20px 6px 20px 6px;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 1.4em 0;
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 8px 20px 8px 20px;
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.72em 0.9em;
+  text-align: left;
+  border-color: #c9d4e3;
+}
+
+.markdown-body th {
+  color: var(--theme-table-heading);
+  font-weight: 650;
+  background: var(--theme-table-heading-surface);
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: #f3f6fb;
+}
+
+.markdown-body :where(img, .mermaid) {
+  border-radius: 20px 6px 20px 6px;
+}
+
+.markdown-body img {
+  margin: 1.5em auto;
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.14em 0.44em;
+  color: var(--theme-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82em;
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-bottom-width: 2px;
+  border-radius: 6px;
+}
+
+.markdown-body mark {
+  padding: 0.08em 0.25em;
+  color: var(--theme-text);
+  background: #e8dfae;
+  border-radius: 4px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #111318;
+    --theme-text: #e3e2e6;
+    --theme-muted: #b9c0cc;
+    --theme-heading: #f1f0f4;
+    --theme-link: #a8c7fa;
+    --theme-accent: #a8c7fa;
+    --theme-secondary: #e5c75d;
+    --theme-focus: #a8c7fa;
+    --theme-border: #526177;
+    --theme-tonal-surface: #26364e;
+    --theme-soft-surface: #1d293b;
+    --theme-quote-text: #d8dce4;
+    --theme-quote-surface: #1c293b;
+    --theme-table-surface: #171d27;
+    --theme-table-heading: #f1f0f4;
+    --theme-table-heading-surface: #26364e;
+    --theme-code-text: #e7edf7;
+    --theme-code-surface: #090e16;
+    --theme-heading-on-accent: #10213a;
+    --theme-diagram-text: #edf0f6;
+    --theme-diagram-surface: #171d27;
+    --theme-diagram-node-surface: #24344c;
+    --theme-diagram-node-border: #a8c7fa;
+    --theme-diagram-line: #9aa8ba;
+    --theme-diagram-label-surface: #171d27;
+    --theme-syntax-comment: #9eabbc;
+    --theme-syntax-keyword: #f0a8c2;
+    --theme-syntax-string: #a8d78c;
+    --theme-syntax-number: #ceb5ff;
+    --theme-syntax-title: #9dceff;
+    --theme-syntax-meta: #efd17f;
+  }
+
+  .markdown-body h1 {
+    border-color: #3d5270;
+  }
+
+  .markdown-body h3 {
+    color: #b9d2ff;
+  }
+
+  .markdown-body code {
+    color: #d7e6ff;
+  }
+
+  .markdown-body :where(th, td) {
+    border-color: #3e4b5e;
+  }
+
+  .markdown-body tbody tr:nth-child(even) {
+    background: #1c2431;
+  }
+
+  .markdown-body mark {
+    color: #f4ecd0;
+    background: #574d22;
+  }
+}

--- a/public/css/markdown-linear.css
+++ b/public/css/markdown-linear.css
@@ -1,0 +1,256 @@
+:root {
+  --theme-canvas: #f7f8fb;
+  --theme-text: #20232b;
+  --theme-muted: #5d6472;
+  --theme-accent: #5b6091;
+  --theme-link: #4c5f91;
+  --theme-border: #cfd5e2;
+  --theme-quote-surface: #f0f2f7;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #f2f4f8;
+  --theme-diagram-text: #20232b;
+  --theme-diagram-node-surface: #eceff5;
+  --theme-diagram-node-border: #66709f;
+  --theme-diagram-line: #737b8b;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-code-text: #eef0f6;
+  --theme-code-surface: #1f222b;
+  --theme-focus: #4f55a5;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-heading: #191c23;
+  --theme-tool-surface: #f1f3f7;
+  --theme-inline-code-surface: #eceff5;
+  --theme-inline-code-text: #454c7b;
+  --theme-strong: #171a20;
+  --theme-surface-radius: 7px;
+  --theme-surface-shadow: none;
+  --theme-body-size: 15px;
+  --theme-reading-width: 840px;
+  --theme-syntax-comment: #aab0bd;
+  --theme-syntax-keyword: #cda7ff;
+  --theme-syntax-string: #9fc6ff;
+  --theme-syntax-number: #b9afff;
+  --theme-syntax-title: #83d0c3;
+  --theme-syntax-meta: #e5b887;
+}
+
+.markdown-body {
+  font-family: var(--theme-font-family);
+  font-size: var(--theme-body-size);
+  line-height: 1.58;
+  letter-spacing: -0.003em;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 650;
+  letter-spacing: -0.022em;
+}
+
+.markdown-body h1 {
+  margin: 0 0 1em;
+  padding-bottom: 0.52em;
+  border-bottom: 1px solid var(--theme-border);
+  font-size: clamp(1.85em, 4.5vw, 2.35em);
+  line-height: 1.12;
+}
+
+.markdown-body h1::after {
+  display: block;
+  inline-size: 3.25rem;
+  block-size: 1px;
+  margin-top: 0.48em;
+  background: linear-gradient(90deg, var(--theme-accent), #607baa);
+  content: "";
+}
+
+.markdown-body h2 {
+  margin: 1.65em 0 0.52em;
+  padding-left: 0.68em;
+  border-left: 2px solid var(--theme-accent);
+  font-size: 1.38em;
+}
+
+.markdown-body h3 {
+  margin: 1.4em 0 0.42em;
+  font-size: 1.15em;
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.2em 0 0.38em;
+}
+
+.markdown-body h6 {
+  color: var(--theme-muted);
+}
+
+.markdown-body p {
+  margin: 0 0 0.82em;
+}
+
+.markdown-body a {
+  font-weight: 560;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-strong);
+  font-weight: 680;
+}
+
+.markdown-body blockquote {
+  margin: 1.15em 0;
+  padding: 0.72em 0.88em;
+  border: 1px solid var(--theme-border);
+  border-left: 2px solid var(--theme-accent);
+  border-radius: var(--theme-surface-radius);
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  padding-left: 1.42em;
+}
+
+.markdown-body li {
+  margin: 0.22em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 1.7em 0;
+  background: var(--theme-border);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.13em 0.32em;
+  color: var(--theme-inline-code-text);
+  background: var(--theme-inline-code-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+}
+
+.markdown-body pre {
+  padding: 0.9em 1em;
+  border-radius: var(--theme-surface-radius);
+  line-height: 1.52;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+.markdown-body table {
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--theme-surface-radius);
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.5em 0.68em;
+}
+
+.markdown-body th {
+  color: var(--theme-heading);
+  background: var(--theme-tool-surface);
+  font-size: 0.8em;
+  font-weight: 680;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: var(--theme-quote-surface);
+}
+
+.markdown-body .mermaid,
+.markdown-body .embedded-svg-container,
+.markdown-body .embedded-mermaid-container {
+  padding: 0.82em;
+  border-radius: var(--theme-surface-radius);
+}
+
+.markdown-body img {
+  border: 1px solid var(--theme-border);
+  border-radius: var(--theme-surface-radius);
+}
+
+.markdown-body kbd {
+  padding: 0.12em 0.36em;
+  color: var(--theme-text);
+  background: var(--theme-tool-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8em;
+}
+
+.markdown-body mark {
+  padding: 0.05em 0.16em;
+  color: var(--theme-text);
+  background: #e4e6f2;
+  border-radius: 3px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #17191f;
+    --theme-text: #e8eaf0;
+    --theme-muted: #a9afbd;
+    --theme-accent: #9c96c9;
+    --theme-link: #aab7e5;
+    --theme-border: #3a3f4c;
+    --theme-quote-surface: #20232a;
+    --theme-table-surface: #1d2027;
+    --theme-diagram-surface: #1e2128;
+    --theme-diagram-text: #e8eaf0;
+    --theme-diagram-node-surface: #252933;
+    --theme-diagram-node-border: #9c96c9;
+    --theme-diagram-line: #8d94a4;
+    --theme-diagram-label-surface: #1d2027;
+    --theme-code-text: #f0f1f5;
+    --theme-code-surface: #101218;
+    --theme-focus: #a7a9e5;
+    --theme-heading-on-accent: #14161c;
+    --theme-heading: #f4f5f8;
+    --theme-tool-surface: #1e2128;
+    --theme-inline-code-surface: #252933;
+    --theme-inline-code-text: #c3c8ed;
+    --theme-strong: #ffffff;
+    --theme-syntax-comment: #969dad;
+    --theme-syntax-keyword: #c7a7f4;
+    --theme-syntax-string: #9cbef0;
+    --theme-syntax-number: #b5ace8;
+    --theme-syntax-title: #89c6bc;
+    --theme-syntax-meta: #d8ad82;
+  }
+
+  .markdown-body mark {
+    color: #eceef5;
+    background: #33364a;
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    font-size: 1.78em;
+  }
+}

--- a/public/css/markdown-notion.css
+++ b/public/css/markdown-notion.css
@@ -1,27 +1,54 @@
-/* ===== Notion 笔记 Markdown 主题 ===== */
-.markdown-body {
-  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  font-size: 16px;
-  line-height: 1.6;
-  color: #37352f;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px;
+/* Notion 笔记 signature: warm-neutral knowledge surfaces and explicit task state. */
+:root {
+  --theme-canvas: #fbfbfa;
+  --theme-text: #37352f;
+  --theme-muted: #5f5e59;
+  --theme-accent: #326b88;
+  --theme-link: #37352f;
+  --theme-border: #d9d8d4;
+  --theme-quote-surface: #f2f1ee;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #f7f6f3;
+  --theme-code-text: #37352f;
+  --theme-code-surface: #f7f6f3;
+  --theme-focus: #005f87;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-diagram-text: #37352f;
+  --theme-diagram-node-surface: #efefed;
+  --theme-diagram-node-border: #63625d;
+  --theme-diagram-line: #5f5e59;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-syntax-comment: #5c625c;
+  --theme-syntax-keyword: #7b3f95;
+  --theme-syntax-string: #246b45;
+  --theme-syntax-number: #9a481c;
+  --theme-syntax-title: #245f87;
+  --theme-syntax-meta: #765300;
+  --theme-reading-width: 900px;
+  --notion-inline-code: #b4232d;
+  --notion-inline-code-surface: #f1efed;
+  --notion-task-open: #6b6a65;
+  --notion-task-complete: #277a4b;
+  --notion-mark-surface: #f8e8e5;
 }
 
-.markdown-body h1, .markdown-body h2, .markdown-body h3,
-.markdown-body h4, .markdown-body h5, .markdown-body h6 {
-  margin-top: 1.5em;
-  margin-bottom: 0.5em;
+.markdown-body {
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  margin-block: 1.5em 0.5em;
+  color: var(--theme-text);
   font-weight: 600;
   line-height: 1.3;
-  color: #37352f;
 }
 
 .markdown-body h1 {
-  font-size: 1.875em;
   padding-bottom: 0.2em;
-  border-bottom: 1px solid #e3e2e0;
+  font-size: 1.875em;
+  border-bottom: 1px solid var(--theme-border);
 }
 
 .markdown-body h2 { font-size: 1.5em; }
@@ -29,129 +56,161 @@
 .markdown-body h4 { font-size: 1.125em; }
 
 .markdown-body p {
-  margin-top: 0;
-  margin-bottom: 1em;
-  line-height: 1.6;
+  margin-block: 0 1em;
 }
 
 .markdown-body blockquote {
-  margin: 0 0 1em 0;
-  padding: 16px;
-  background: #f7f6f3;
-  border-left: 3px solid #e9e9e7;
+  margin: 0 0 1em;
+  padding: 1em;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border-left: 3px solid var(--theme-border);
   border-radius: 3px;
-  color: #37352f;
-  font-style: normal;
 }
 
-.markdown-body strong { font-weight: 600; color: #37352f; }
-.markdown-body em { font-style: italic; }
+.markdown-body strong {
+  color: var(--theme-text);
+  font-weight: 600;
+}
 
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 1em;
-  padding: 16px;
-  overflow: auto;
-  font-size: 14px;
-  line-height: 1.5;
-  color: #37352f;
-  background-color: #f7f6f3;
-  border-radius: 3px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace;
+.markdown-body a {
+  color: var(--theme-link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.markdown-body a:hover {
+  color: var(--theme-accent);
 }
 
 .markdown-body code {
-  font-size: 90%;
-  padding: 2px 4px;
-  background: #f1f1ef;
-  color: #eb5757;
+  padding: 0.12em 0.35em;
+  color: var(--notion-inline-code);
+  background: var(--notion-inline-code-surface);
   border-radius: 3px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 90%;
+}
+
+.markdown-body pre {
+  margin-block: 0 1em;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
 .markdown-body pre code {
   padding: 0;
-  background: transparent;
   color: inherit;
+  background: transparent;
   border-radius: 0;
   font-size: 100%;
 }
 
-.markdown-body a {
-  color: #37352f;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  transition: color 0.15s ease;
-}
-
-.markdown-body a:hover { color: #e16259; }
-
-.markdown-body img {
-  max-width: 100%;
-  border-radius: 3px;
-  display: block;
-  margin: 1em auto;
-}
-
 .markdown-body table {
-  width: 100%;
-  border-collapse: collapse;
   margin-bottom: 1em;
-  border: 1px solid #e3e2e0;
   border-radius: 3px;
-  overflow: hidden;
 }
 
-.markdown-body th, .markdown-body td {
-  padding: 10px 14px;
-  border: 1px solid #e3e2e0;
+.markdown-body :where(th, td) {
+  padding: 0.625em 0.875em;
   text-align: left;
 }
 
 .markdown-body th {
+  color: var(--theme-text);
+  background: var(--theme-quote-surface);
   font-weight: 600;
-  background: #f7f6f3;
-  color: #37352f;
 }
-
-.markdown-body td { color: #37352f; }
 
 .markdown-body hr {
   height: 1px;
-  padding: 0;
   margin: 1.5em 0;
-  background: #e3e2e0;
+  background: var(--theme-border);
   border: 0;
 }
 
-.markdown-body ul, .markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 1em;
+.markdown-body :where(ul, ol) {
+  margin-block: 0 1em;
   padding-left: 2em;
 }
 
-.markdown-body li { margin-bottom: 0.25em; }
+.markdown-body li {
+  margin-bottom: 0.25em;
+}
 
-.markdown-body input[type="checkbox"] {
-  margin-right: 6px;
-  accent-color: #2eaadc;
+.markdown-body input[type="checkbox"]:not(:checked) {
+  accent-color: var(--notion-task-open);
+}
+
+.markdown-body input[type="checkbox"]:checked {
+  accent-color: var(--notion-task-complete);
+}
+
+.markdown-body li:has(> input[type="checkbox"]:checked) {
+  color: var(--theme-muted);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body img {
+  margin: 1em auto;
+  border-radius: 3px;
 }
 
 .markdown-body kbd {
   display: inline-block;
-  padding: 3px 5px;
-  font-size: 11px;
-  line-height: 1.3;
-  color: #37352f;
-  background: #f7f6f3;
-  border: 1px solid #e3e2e0;
+  padding: 0.2em 0.4em;
+  color: var(--theme-text);
+  background: var(--theme-quote-surface);
+  border: 1px solid var(--theme-border);
   border-radius: 3px;
-  font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75em;
+  line-height: 1.3;
 }
 
 .markdown-body mark {
-  background: rgba(225, 98, 89, 0.1);
-  color: #37352f;
-  padding: 0 4px;
+  padding-inline: 0.25em;
+  color: var(--theme-text);
+  background: var(--notion-mark-surface);
   border-radius: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #191919;
+    --theme-text: #e8e7e3;
+    --theme-muted: #b9b7b0;
+    --theme-accent: #74b4d3;
+    --theme-link: #e8e7e3;
+    --theme-border: #4d4c48;
+    --theme-quote-surface: #272726;
+    --theme-table-surface: #222221;
+    --theme-diagram-surface: #222221;
+    --theme-code-text: #e8e7e3;
+    --theme-code-surface: #242423;
+    --theme-focus: #71c7e8;
+    --theme-heading-on-accent: #111111;
+    --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+    --theme-diagram-text: #e8e7e3;
+    --theme-diagram-node-surface: #30302e;
+    --theme-diagram-node-border: #aaa8a1;
+    --theme-diagram-line: #b9b7b0;
+    --theme-diagram-label-surface: #222221;
+    --theme-syntax-comment: #b1b7ae;
+    --theme-syntax-keyword: #d7a0ee;
+    --theme-syntax-string: #8ed3aa;
+    --theme-syntax-number: #f0ad86;
+    --theme-syntax-title: #8cc8ed;
+    --theme-syntax-meta: #dfc478;
+    --theme-reading-width: 900px;
+    --notion-inline-code: #ff9b9b;
+    --notion-inline-code-surface: #312727;
+    --notion-task-open: #aaa8a1;
+    --notion-task-complete: #75c99a;
+    --notion-mark-surface: #49312f;
+  }
 }

--- a/public/css/markdown-notion.css
+++ b/public/css/markdown-notion.css
@@ -54,6 +54,7 @@
   overflow: auto;
   font-size: 14px;
   line-height: 1.5;
+  color: #37352f;
   background-color: #f7f6f3;
   border-radius: 3px;
   font-family: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, monospace;

--- a/public/css/markdown-playstation.css
+++ b/public/css/markdown-playstation.css
@@ -1,0 +1,329 @@
+/* PlayStation 蓝境 — geometric blue-depth Markdown signature */
+
+:root {
+  --theme-reading-width: 880px;
+  --theme-canvas: #f1f7ff;
+  --theme-text: #18304f;
+  --theme-muted: #536b87;
+  --theme-heading: #102b4d;
+  --theme-link: #0058b8;
+  --theme-accent: #0068dc;
+  --theme-secondary: #1d9bf0;
+  --theme-focus: #005ac2;
+  --theme-border: #b9cee5;
+  --theme-subtle-border: #d2e1f1;
+  --theme-soft-surface: #e5f1ff;
+  --theme-quote-surface: #e3f0ff;
+  --theme-quote-text: #334f70;
+  --theme-table-surface: #f8fbff;
+  --theme-table-heading-surface: #dbeaff;
+  --theme-table-heading: #183b67;
+  --theme-code-surface: #081b35;
+  --theme-code-text: #edf7ff;
+  --theme-heading-gradient-start: #0055c7;
+  --theme-heading-gradient-end: #006bd6;
+  --theme-heading-on-accent: #ffffff;
+  --theme-diagram-surface: #f8fbff;
+  --theme-diagram-text: #173a62;
+  --theme-diagram-node-surface: #deedff;
+  --theme-diagram-node-border: #0068dc;
+  --theme-diagram-line: #52749a;
+  --theme-diagram-label-surface: #f8fbff;
+  --theme-syntax-comment: #a8bed7;
+  --theme-syntax-keyword: #8fc9ff;
+  --theme-syntax-string: #8fe2ca;
+  --theme-syntax-number: #d0b6ff;
+  --theme-syntax-title: #f2cb78;
+  --theme-syntax-meta: #ff9eb7;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+}
+
+.markdown-body {
+  color: var(--theme-text);
+  font-family: var(--theme-font-family);
+  font-size: 16px;
+  line-height: 1.72;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 680;
+  line-height: 1.22;
+  letter-spacing: -0.018em;
+}
+
+.markdown-body h1 {
+  position: relative;
+  isolation: isolate;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 0 1.4em;
+  padding: 0.7em 1.45em 0.7em 0.85em;
+  overflow: hidden;
+  background: linear-gradient(118deg, var(--theme-heading-gradient-start), var(--theme-heading-gradient-end));
+  color: var(--theme-heading-on-accent);
+  font-size: clamp(1.9rem, 5vw, 2.75rem);
+  border-radius: 4px 18px 4px 4px;
+}
+
+.markdown-body h1::after {
+  position: absolute;
+  z-index: -1;
+  inset: 0 0 0 auto;
+  width: 28%;
+  background: rgba(255, 255, 255, 0.16);
+  clip-path: polygon(100% 0, 100% 100%, 0 100%);
+  content: "";
+  pointer-events: none;
+}
+
+.markdown-body h2 {
+  margin: 2.25em 0 0.85em;
+  padding: 0.25em 0 0.32em 0.75em;
+  font-size: clamp(1.4rem, 3.5vw, 1.75rem);
+  border-bottom: 2px solid var(--theme-subtle-border);
+  border-left: 5px solid var(--theme-accent);
+}
+
+.markdown-body h3 {
+  margin: 1.9em 0 0.7em;
+  color: #074f9e;
+  font-size: 1.22rem;
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.6em 0 0.55em;
+}
+
+.markdown-body h6 {
+  color: var(--theme-muted);
+}
+
+.markdown-body p {
+  margin: 0 0 1.15em;
+}
+
+.markdown-body a {
+  font-weight: 600;
+  text-decoration-thickness: 1px;
+  text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
+}
+
+.markdown-body a:hover {
+  color: #003f87;
+  text-decoration-color: currentColor;
+}
+
+.markdown-body :where(strong, b) {
+  color: #0a4c91;
+  font-weight: 720;
+}
+
+.markdown-body blockquote {
+  margin: 1.45em 0;
+  padding: 0.95em 1.1em;
+  color: var(--theme-quote-text);
+  background: var(--theme-quote-surface);
+  border: 1px solid #bfd8f2;
+  border-left: 5px solid var(--theme-secondary);
+  border-radius: 3px 12px 12px 3px;
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.15em;
+  padding-left: 1.7em;
+}
+
+.markdown-body li {
+  margin: 0.32em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+  font-weight: 700;
+}
+
+.markdown-body hr {
+  height: 2px;
+  margin: 2.3em 0;
+  background: linear-gradient(90deg, var(--theme-accent), var(--theme-secondary), transparent 82%);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.14em 0.38em;
+  color: #084b91;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: var(--theme-soft-surface);
+  border: 1px solid #c5dcf4;
+  border-radius: 4px;
+}
+
+.markdown-body pre {
+  margin: 1.4em 0;
+  padding: 1.15em 1.25em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.65;
+  background: var(--theme-code-surface);
+  border: 1px solid #24466f;
+  border-top: 4px solid var(--theme-secondary);
+  border-radius: 4px 12px 4px 4px;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 1.45em 0;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 4px 12px 4px 4px;
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.68em 0.9em;
+  text-align: left;
+  border: 1px solid var(--theme-subtle-border);
+}
+
+.markdown-body th {
+  color: var(--theme-table-heading);
+  font-weight: 700;
+  background: var(--theme-table-heading-surface);
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: rgba(0, 104, 220, 0.035);
+}
+
+.markdown-body img {
+  margin: 1.4em auto;
+  border: 1px solid var(--theme-border);
+  border-radius: 4px 14px 4px 4px;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.16em 0.45em;
+  color: #173c68;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82em;
+  background: #f8fbff;
+  border: 1px solid #a9c1da;
+  border-bottom-width: 2px;
+  border-radius: 4px;
+}
+
+.markdown-body mark {
+  padding: 0.08em 0.25em;
+  color: #14365e;
+  background: #cde8ff;
+  border-radius: 2px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+.markdown-body .mermaid {
+  color: var(--theme-diagram-text);
+  background: var(--theme-diagram-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 4px 12px 4px 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #071629;
+    --theme-text: #e8f3ff;
+    --theme-muted: #a8bfd8;
+    --theme-heading: #f1f7ff;
+    --theme-link: #79c8ff;
+    --theme-accent: #55b7ff;
+    --theme-secondary: #8cddff;
+    --theme-focus: #5ed7ff;
+    --theme-border: #355574;
+    --theme-subtle-border: #294764;
+    --theme-soft-surface: #112e4f;
+    --theme-quote-surface: #102c4b;
+    --theme-quote-text: #d2e6fb;
+    --theme-table-surface: #0d223b;
+    --theme-table-heading-surface: #143254;
+    --theme-table-heading: #e6f3ff;
+    --theme-code-surface: #020b18;
+    --theme-code-text: #f1f8ff;
+    --theme-heading-gradient-start: #62c4ff;
+    --theme-heading-gradient-end: #b4e7ff;
+    --theme-heading-on-accent: #06213c;
+    --theme-diagram-surface: #0d223b;
+    --theme-diagram-text: #e5f2ff;
+    --theme-diagram-node-surface: #17385c;
+    --theme-diagram-node-border: #67c9ff;
+    --theme-diagram-line: #8daeca;
+    --theme-diagram-label-surface: #0d223b;
+    --theme-syntax-comment: #91abc4;
+    --theme-syntax-keyword: #8fd2ff;
+    --theme-syntax-string: #88e1c9;
+    --theme-syntax-number: #ceb7ff;
+    --theme-syntax-title: #f1cb7a;
+    --theme-syntax-meta: #ff9eb7;
+  }
+
+  .markdown-body h1::after {
+    background: rgba(255, 255, 255, 0.22);
+  }
+
+  .markdown-body h3,
+  .markdown-body :where(strong, b) {
+    color: #a8d8ff;
+  }
+
+  .markdown-body a:hover {
+    color: #b5e2ff;
+  }
+
+  .markdown-body blockquote {
+    border-color: #294d6d;
+    border-left-color: var(--theme-secondary);
+  }
+
+  .markdown-body code {
+    color: #b9ddff;
+    border-color: #2c5275;
+  }
+
+  .markdown-body tbody tr:nth-child(even) {
+    background: rgba(85, 183, 255, 0.05);
+  }
+
+  .markdown-body kbd {
+    color: #dceeff;
+    background: #173451;
+    border-color: #547594;
+  }
+
+  .markdown-body mark {
+    color: #eaf6ff;
+    background: #225a83;
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    width: 100%;
+    padding-inline: 0.75em 1.15em;
+  }
+}

--- a/public/css/markdown-raycast.css
+++ b/public/css/markdown-raycast.css
@@ -1,0 +1,281 @@
+:root {
+  --theme-canvas: #f4f1f6;
+  --theme-text: #251f29;
+  --theme-muted: #625969;
+  --theme-accent: #7443a8;
+  --theme-link: #674096;
+  --theme-border: #c8becf;
+  --theme-quote-surface: #e9e0ed;
+  --theme-table-surface: #fbf9fc;
+  --theme-diagram-surface: #eee7f1;
+  --theme-diagram-text: #251f29;
+  --theme-diagram-node-surface: #e4d7e9;
+  --theme-diagram-node-border: #7443a8;
+  --theme-diagram-line: #665d6d;
+  --theme-diagram-label-surface: #fbf9fc;
+  --theme-code-text: #f8f1fb;
+  --theme-code-surface: #24192a;
+  --theme-focus: #6d3caf;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-heading: #211a25;
+  --theme-tool-surface: #e7ddea;
+  --theme-heading-surface: #35283b;
+  --theme-inline-code-surface: #e5daea;
+  --theme-inline-code-text: #552878;
+  --theme-strong: #301b39;
+  --theme-surface-radius: 12px;
+  --theme-surface-shadow: inset 0 1px 0 #ffffff;
+  --theme-body-size: 16px;
+  --theme-reading-width: 880px;
+  --theme-syntax-comment: #c3b4c8;
+  --theme-syntax-keyword: #ff8bd4;
+  --theme-syntax-string: #c7a2ff;
+  --theme-syntax-number: #efa8ff;
+  --theme-syntax-title: #9db7ff;
+  --theme-syntax-meta: #f3b6d5;
+}
+
+.markdown-body {
+  font-family: var(--theme-font-family);
+  font-size: var(--theme-body-size);
+  line-height: 1.68;
+  letter-spacing: -0.006em;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 680;
+  letter-spacing: -0.025em;
+}
+
+.markdown-body h1 {
+  margin: 0 0 1.15em;
+  padding: 0.9em 1em;
+  color: var(--theme-heading-on-accent);
+  background: linear-gradient(145deg, var(--theme-heading-surface), var(--theme-code-surface));
+  border: 1px solid var(--theme-border);
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+  font-size: clamp(1.9em, 5vw, 2.55em);
+  line-height: 1.08;
+}
+
+.markdown-body h2 {
+  margin: 1.9em 0 0.7em;
+  padding-bottom: 0.38em;
+  border-bottom: 1px solid var(--theme-border);
+  font-size: 1.52em;
+}
+
+.markdown-body h2::before {
+  display: inline-block;
+  inline-size: 0.52em;
+  block-size: 0.52em;
+  margin-inline-end: 0.48em;
+  background: linear-gradient(135deg, var(--theme-accent), #b83f91);
+  border-radius: 4px;
+  content: "";
+}
+
+.markdown-body h3 {
+  margin: 1.6em 0 0.55em;
+  padding-left: 0.72em;
+  border-left: 3px solid var(--theme-accent);
+  font-size: 1.22em;
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.35em 0 0.45em;
+}
+
+.markdown-body h6 {
+  color: var(--theme-muted);
+}
+
+.markdown-body p {
+  margin: 0 0 1em;
+}
+
+.markdown-body a {
+  font-weight: 600;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-strong);
+  font-weight: 700;
+}
+
+.markdown-body blockquote {
+  padding: 1em 1.1em;
+  border: 1px solid var(--theme-border);
+  border-left: 4px solid var(--theme-accent);
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  padding-left: 1.55em;
+}
+
+.markdown-body li {
+  margin: 0.32em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-accent);
+  font-weight: 700;
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 2.1em 0;
+  background: linear-gradient(90deg, transparent, var(--theme-border), var(--theme-accent), transparent);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.16em 0.38em;
+  color: var(--theme-inline-code-text);
+  background: var(--theme-inline-code-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+}
+
+.markdown-body pre {
+  padding: 1.15em 1.2em;
+  border-color: #594460;
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+  line-height: 1.58;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+}
+
+.markdown-body table {
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.65em 0.8em;
+}
+
+.markdown-body th {
+  color: var(--theme-heading);
+  background: var(--theme-tool-surface);
+  font-size: 0.86em;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background: var(--theme-quote-surface);
+}
+
+.markdown-body .mermaid,
+.markdown-body .embedded-svg-container,
+.markdown-body .embedded-mermaid-container {
+  padding: 1em;
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body img {
+  border: 1px solid var(--theme-border);
+  border-radius: var(--theme-surface-radius);
+  box-shadow: var(--theme-surface-shadow);
+}
+
+.markdown-body kbd {
+  padding: 0.16em 0.42em;
+  color: var(--theme-text);
+  background: var(--theme-tool-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 5px;
+  box-shadow: var(--theme-surface-shadow);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.84em;
+}
+
+.markdown-body mark {
+  padding: 0.08em 0.2em;
+  color: var(--theme-text);
+  background: #ead4ef;
+  border-radius: 4px;
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #151119;
+    --theme-text: #f0eaf3;
+    --theme-muted: #bdb2c2;
+    --theme-accent: #c88bea;
+    --theme-link: #d1a4f0;
+    --theme-border: #4b3c52;
+    --theme-quote-surface: #251b2b;
+    --theme-table-surface: #1d1722;
+    --theme-diagram-surface: #211925;
+    --theme-diagram-text: #f0eaf3;
+    --theme-diagram-node-surface: #2e2134;
+    --theme-diagram-node-border: #c88bea;
+    --theme-diagram-line: #a999b0;
+    --theme-diagram-label-surface: #1d1722;
+    --theme-code-text: #f6eef8;
+    --theme-code-surface: #0f0b12;
+    --theme-focus: #da9cff;
+    --theme-heading-on-accent: #ffffff;
+    --theme-heading: #fbf7fc;
+    --theme-tool-surface: #251b2b;
+    --theme-heading-surface: #3a2741;
+    --theme-inline-code-surface: #2d2034;
+    --theme-inline-code-text: #e7b9f3;
+    --theme-strong: #ffffff;
+    --theme-surface-shadow: inset 0 1px 0 #5d4865;
+    --theme-syntax-comment: #ad9eb3;
+    --theme-syntax-keyword: #ff91d8;
+    --theme-syntax-string: #c9a8ff;
+    --theme-syntax-number: #efa8ff;
+    --theme-syntax-title: #a9c1ff;
+    --theme-syntax-meta: #f3b6d5;
+  }
+
+  .markdown-body h1 {
+    border-color: #5b4663;
+  }
+
+  .markdown-body pre {
+    border-color: #4b3c52;
+  }
+
+  .markdown-body mark {
+    color: #f7eef9;
+    background: #503257;
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    padding: 0.78em 0.82em;
+    font-size: 1.82em;
+  }
+}

--- a/public/css/markdown-tesla.css
+++ b/public/css/markdown-tesla.css
@@ -1,0 +1,270 @@
+/* Tesla 黑白 — precise monochrome Markdown signature */
+
+:root {
+  --theme-canvas: #ffffff;
+  --theme-text: #050505;
+  --theme-muted: #555555;
+  --theme-heading: #000000;
+  --theme-accent: #000000;
+  --theme-link: #111111;
+  --theme-border: #9a9a9a;
+  --theme-specification: #717171;
+  --theme-quote-surface: #f4f4f4;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #ffffff;
+  --theme-diagram-text: #050505;
+  --theme-diagram-node-surface: #f4f4f4;
+  --theme-diagram-node-border: #050505;
+  --theme-diagram-line: #555555;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-code-text: #f7f7f7;
+  --theme-code-surface: #080808;
+  --theme-focus: #000000;
+  --theme-heading-on-accent: #ffffff;
+  --theme-syntax-comment: #b8b8b8;
+  --theme-syntax-keyword: #ffffff;
+  --theme-syntax-string: #d4d4d4;
+  --theme-syntax-number: #efefef;
+  --theme-syntax-title: #ffffff;
+  --theme-syntax-meta: #c5c5c5;
+  --theme-reading-width: 920px;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+}
+
+.markdown-body {
+  color: var(--theme-text);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.68;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--theme-heading);
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+.markdown-body h1 {
+  margin: 0 0 0.72em;
+  padding: 0.22em 0;
+  font-size: clamp(2.75rem, 7.5vw, 5.5rem);
+  font-weight: 800;
+  letter-spacing: 0.045em;
+  line-height: 0.94;
+  text-transform: uppercase;
+  border-top: 1px solid var(--theme-specification);
+  border-bottom: 1px solid var(--theme-specification);
+}
+
+.theme-sampler .markdown-body h1 {
+  font-size: clamp(1.45rem, 4vw, 2.25rem);
+  letter-spacing: 0.035em;
+  line-height: 1;
+}
+
+.markdown-theme-sampler .markdown-body h1 {
+  font-size: clamp(1.45rem, 4vw, 2.25rem);
+  letter-spacing: 0.035em;
+  line-height: 1;
+}
+
+.markdown-body h2 {
+  margin: 2.4em 0 0.8em;
+  padding-bottom: 0.35em;
+  font-size: clamp(1.55rem, 3vw, 2rem);
+  letter-spacing: 0.01em;
+  border-bottom: 1px solid var(--theme-specification);
+}
+
+.markdown-body h3 {
+  margin: 2em 0 0.65em;
+  font-size: 1.24rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.markdown-body :where(h4, h5, h6) {
+  margin: 1.7em 0 0.55em;
+  letter-spacing: 0.035em;
+}
+
+.markdown-body p {
+  margin: 0 0 1.15em;
+}
+
+.markdown-body a {
+  color: var(--theme-link);
+  font-weight: 650;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-body a:hover {
+  text-decoration-thickness: 2px;
+}
+
+.markdown-body :where(strong, b) {
+  color: var(--theme-heading);
+  font-weight: 800;
+}
+
+.markdown-body blockquote {
+  margin: 1.5em 0;
+  padding: 0.8em 1em;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border: 0;
+  border-left: 2px solid var(--theme-accent);
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body :where(ul, ol) {
+  margin: 0 0 1.2em;
+  padding-left: 1.55em;
+}
+
+.markdown-body li {
+  margin: 0.3em 0;
+}
+
+.markdown-body li::marker {
+  color: var(--theme-heading);
+  font-weight: 700;
+}
+
+.markdown-body hr {
+  height: 1px;
+  margin: 2.5em 0;
+  background: var(--theme-specification);
+  border: 0;
+}
+
+.markdown-body code {
+  padding: 0.12em 0.32em;
+  color: var(--theme-heading);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88em;
+  background: var(--theme-quote-surface);
+  border: 1px solid var(--theme-border);
+  border-radius: 0;
+}
+
+.markdown-body pre {
+  margin: 1.45em 0;
+  padding: 1.1em 1.2em;
+  color: var(--theme-code-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.88rem;
+  line-height: 1.62;
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-code-surface);
+  border-radius: 0;
+}
+
+.markdown-body pre code {
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body table {
+  margin: 1.5em 0;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-specification);
+  border-radius: 0;
+}
+
+.markdown-body :where(th, td) {
+  padding: 0.62em 0.78em;
+  text-align: left;
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body th {
+  color: var(--theme-heading);
+  font-size: 0.78em;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--theme-quote-surface);
+}
+
+.markdown-body img {
+  margin: 1.5em auto;
+  border: 1px solid var(--theme-specification);
+  border-radius: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: 0.1em 0.38em;
+  color: var(--theme-heading);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82em;
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-heading);
+  border-radius: 0;
+}
+
+.markdown-body mark {
+  padding: 0.05em 0.2em;
+  color: var(--theme-heading-on-accent);
+  background: var(--theme-accent);
+}
+
+.markdown-body input[type="checkbox"] {
+  accent-color: var(--theme-accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #050505;
+    --theme-text: #f5f5f5;
+    --theme-muted: #b9b9b9;
+    --theme-heading: #ffffff;
+    --theme-accent: #ffffff;
+    --theme-link: #ffffff;
+    --theme-border: #666666;
+    --theme-specification: #8a8a8a;
+    --theme-quote-surface: #111111;
+    --theme-table-surface: #080808;
+    --theme-diagram-surface: #080808;
+    --theme-diagram-text: #f5f5f5;
+    --theme-diagram-node-surface: #111111;
+    --theme-diagram-node-border: #f5f5f5;
+    --theme-diagram-line: #b9b9b9;
+    --theme-diagram-label-surface: #080808;
+    --theme-code-text: #050505;
+    --theme-code-surface: #f5f5f5;
+    --theme-focus: #ffffff;
+    --theme-heading-on-accent: #050505;
+    --theme-syntax-comment: #4f4f4f;
+    --theme-syntax-keyword: #050505;
+    --theme-syntax-string: #242424;
+    --theme-syntax-number: #111111;
+    --theme-syntax-title: #000000;
+    --theme-syntax-meta: #333333;
+  }
+
+  .markdown-body code {
+    color: var(--theme-text);
+  }
+}
+
+@media (max-width: 480px) {
+  .markdown-body h1 {
+    font-size: clamp(2.1rem, 13vw, 3.15rem);
+    letter-spacing: 0.025em;
+  }
+
+  .theme-sampler .markdown-body h1,
+  .markdown-theme-sampler .markdown-body h1 {
+    font-size: clamp(1.35rem, 8vw, 1.85rem);
+  }
+}

--- a/public/css/markdown-theme-baseline.css
+++ b/public/css/markdown-theme-baseline.css
@@ -19,12 +19,6 @@
   --theme-diagram-node-border: #2563eb;
   --theme-diagram-line: #64748b;
   --theme-diagram-label-surface: #ffffff;
-  --theme-syntax-comment: #9aa9bd;
-  --theme-syntax-keyword: #f58ac3;
-  --theme-syntax-string: #a7db78;
-  --theme-syntax-number: #d6a6ff;
-  --theme-syntax-title: #7cc7ff;
-  --theme-syntax-meta: #ffd166;
   --theme-reading-width: 900px;
   --theme-reading-padding: clamp(24px, 5vw, 56px);
 }
@@ -127,32 +121,32 @@ body {
 
 .markdown-body .hljs {
   display: block;
-  color: var(--theme-code-text);
+  color: inherit;
   background: transparent;
 }
 
 .markdown-body :where(.hljs-comment, .hljs-quote) {
-  color: var(--theme-syntax-comment);
+  color: var(--theme-syntax-comment, currentColor);
 }
 
 .markdown-body :where(.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-type) {
-  color: var(--theme-syntax-keyword);
+  color: var(--theme-syntax-keyword, currentColor);
 }
 
 .markdown-body :where(.hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute) {
-  color: var(--theme-syntax-string);
+  color: var(--theme-syntax-string, currentColor);
 }
 
 .markdown-body :where(.hljs-number, .hljs-symbol, .hljs-bullet) {
-  color: var(--theme-syntax-number);
+  color: var(--theme-syntax-number, currentColor);
 }
 
 .markdown-body :where(.hljs-title, .hljs-section, .hljs-name, .hljs-selector-id, .hljs-selector-class) {
-  color: var(--theme-syntax-title);
+  color: var(--theme-syntax-title, currentColor);
 }
 
 .markdown-body :where(.hljs-meta, .hljs-built_in, .hljs-variable, .hljs-template-variable) {
-  color: var(--theme-syntax-meta);
+  color: var(--theme-syntax-meta, currentColor);
 }
 
 .markdown-body table {
@@ -260,12 +254,6 @@ body {
     --theme-diagram-node-border: #7db4ff;
     --theme-diagram-line: #93a4ba;
     --theme-diagram-label-surface: #182235;
-    --theme-syntax-comment: #9aa9bd;
-    --theme-syntax-keyword: #f58ac3;
-    --theme-syntax-string: #a7db78;
-    --theme-syntax-number: #d6a6ff;
-    --theme-syntax-title: #7cc7ff;
-    --theme-syntax-meta: #ffd166;
   }
 }
 

--- a/public/css/markdown-theme-baseline.css
+++ b/public/css/markdown-theme-baseline.css
@@ -204,7 +204,7 @@ body {
   margin-inline: auto;
 }
 
-.markdown-body :where(.task-list-item) {
+.markdown-body :where(.task-list-item, li:has(> input[type="checkbox"])) {
   list-style: none;
 }
 

--- a/public/css/markdown-theme-baseline.css
+++ b/public/css/markdown-theme-baseline.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: light dark;
+  --theme-canvas: #f5f7fa;
+  --theme-text: #243147;
+  --theme-muted: #52627a;
+  --theme-link: #095fba;
+  --theme-focus: #0b6cf0;
+  --theme-reading-width: 900px;
+  --theme-reading-padding: clamp(24px, 5vw, 56px);
+}
+
+html {
+  min-width: 0;
+  background: var(--theme-canvas);
+  scroll-padding-top: 1rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  min-width: 0;
+  min-height: 100vh;
+  margin: 0;
+  background: var(--theme-canvas);
+  color: var(--theme-text);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.markdown-body {
+  width: min(100%, var(--theme-reading-width));
+  min-width: 0;
+  margin-inline: auto;
+  padding: var(--theme-reading-padding) clamp(20px, 4vw, 48px);
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.markdown-body > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.markdown-body :where(h1, h2, h3, h4, h5, h6) {
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+.markdown-body :where(a, button, input, textarea, select, summary, [tabindex]):focus-visible {
+  outline: 3px solid var(--theme-focus);
+  outline-offset: 3px;
+}
+
+.markdown-body a {
+  color: var(--theme-link);
+  text-underline-offset: 0.18em;
+}
+
+.markdown-body :where(img, video, canvas, iframe) {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown-body :where(svg) {
+  max-width: 100%;
+}
+
+.markdown-body :where(pre, table, .mermaid, .embedded-svg-container, .embedded-mermaid-container) {
+  min-width: 0;
+  max-width: 100%;
+  overflow: auto;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.markdown-body pre {
+  white-space: pre;
+}
+
+.markdown-body pre code {
+  overflow-wrap: normal;
+  word-break: normal;
+  white-space: inherit;
+}
+
+.markdown-body table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  border-collapse: collapse;
+}
+
+.markdown-body :where(th, td) {
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.markdown-body .mermaid svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-inline: auto;
+}
+
+.markdown-body :where(.task-list-item) {
+  list-style: none;
+}
+
+.markdown-body input[type="checkbox"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0 0.5rem 0 0;
+  vertical-align: -0.12em;
+}
+
+.markdown-body :where(p, li, blockquote, figcaption) {
+  orphans: 3;
+  widows: 3;
+}
+
+@media (max-width: 480px) {
+  :root {
+    --theme-reading-padding: 24px;
+  }
+
+  .markdown-body {
+    padding-inline: 16px;
+  }
+
+  .markdown-body :where(pre, table, .mermaid, .embedded-svg-container) {
+    scrollbar-width: thin;
+  }
+}
+
+@media (forced-colors: active) {
+  .markdown-body :where(a, button, input, textarea, select, summary, [tabindex]):focus-visible {
+    outline-color: Highlight;
+  }
+}
+
+@media print {
+  :root {
+    --theme-canvas: #ffffff;
+  }
+
+  .markdown-body {
+    width: 100%;
+    max-width: none;
+    padding: 0;
+  }
+}

--- a/public/css/markdown-theme-baseline.css
+++ b/public/css/markdown-theme-baseline.css
@@ -3,8 +3,28 @@
   --theme-canvas: #f5f7fa;
   --theme-text: #243147;
   --theme-muted: #52627a;
+  --theme-accent: #2563eb;
   --theme-link: #095fba;
+  --theme-border: #cbd5e1;
+  --theme-quote-surface: #f1f5f9;
+  --theme-table-surface: #ffffff;
+  --theme-diagram-surface: #ffffff;
+  --theme-code-text: #e5edf7;
+  --theme-code-surface: #172033;
   --theme-focus: #0b6cf0;
+  --theme-heading-on-accent: #ffffff;
+  --theme-font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", Arial, sans-serif;
+  --theme-diagram-text: #243147;
+  --theme-diagram-node-surface: #f1f5f9;
+  --theme-diagram-node-border: #2563eb;
+  --theme-diagram-line: #64748b;
+  --theme-diagram-label-surface: #ffffff;
+  --theme-syntax-comment: #9aa9bd;
+  --theme-syntax-keyword: #f58ac3;
+  --theme-syntax-string: #a7db78;
+  --theme-syntax-number: #d6a6ff;
+  --theme-syntax-title: #7cc7ff;
+  --theme-syntax-meta: #ffd166;
   --theme-reading-width: 900px;
   --theme-reading-padding: clamp(24px, 5vw, 56px);
 }
@@ -37,6 +57,10 @@ body {
   min-width: 0;
   margin-inline: auto;
   padding: var(--theme-reading-padding) clamp(20px, 4vw, 48px);
+  color: var(--theme-text);
+  font-family: var(--theme-font-family);
+  font-size: 16px;
+  line-height: 1.65;
   overflow-wrap: anywhere;
   word-break: normal;
 }
@@ -61,6 +85,14 @@ body {
   text-underline-offset: 0.18em;
 }
 
+.markdown-body blockquote {
+  margin: 1.4em 0;
+  padding: 0.85em 1em;
+  color: var(--theme-muted);
+  background: var(--theme-quote-surface);
+  border-left: 4px solid var(--theme-accent);
+}
+
 .markdown-body :where(img, video, canvas, iframe) {
   display: block;
   max-width: 100%;
@@ -80,6 +112,10 @@ body {
 }
 
 .markdown-body pre {
+  padding: 1em;
+  color: var(--theme-code-text);
+  background: var(--theme-code-surface);
+  border: 1px solid var(--theme-border);
   white-space: pre;
 }
 
@@ -89,16 +125,82 @@ body {
   white-space: inherit;
 }
 
+.markdown-body .hljs {
+  display: block;
+  color: var(--theme-code-text);
+  background: transparent;
+}
+
+.markdown-body :where(.hljs-comment, .hljs-quote) {
+  color: var(--theme-syntax-comment);
+}
+
+.markdown-body :where(.hljs-keyword, .hljs-selector-tag, .hljs-literal, .hljs-type) {
+  color: var(--theme-syntax-keyword);
+}
+
+.markdown-body :where(.hljs-string, .hljs-regexp, .hljs-addition, .hljs-attribute) {
+  color: var(--theme-syntax-string);
+}
+
+.markdown-body :where(.hljs-number, .hljs-symbol, .hljs-bullet) {
+  color: var(--theme-syntax-number);
+}
+
+.markdown-body :where(.hljs-title, .hljs-section, .hljs-name, .hljs-selector-id, .hljs-selector-class) {
+  color: var(--theme-syntax-title);
+}
+
+.markdown-body :where(.hljs-meta, .hljs-built_in, .hljs-variable, .hljs-template-variable) {
+  color: var(--theme-syntax-meta);
+}
+
 .markdown-body table {
   display: block;
   width: max-content;
   max-width: 100%;
+  color: var(--theme-text);
+  background: var(--theme-table-surface);
+  border: 1px solid var(--theme-border);
   border-collapse: collapse;
 }
 
 .markdown-body :where(th, td) {
+  padding: 0.65em 0.8em;
   overflow-wrap: normal;
   word-break: normal;
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body .mermaid {
+  color: var(--theme-text);
+  background: var(--theme-diagram-surface);
+  border: 1px solid var(--theme-border);
+}
+
+.markdown-body .mermaid :where(.node rect, .node circle, .node ellipse, .node polygon, .node path) {
+  fill: var(--theme-diagram-node-surface) !important;
+  stroke: var(--theme-diagram-node-border) !important;
+}
+
+.markdown-body .mermaid :where(text, .label, .nodeLabel, .nodeLabel p, .nodeLabel span) {
+  color: var(--theme-diagram-text) !important;
+  fill: var(--theme-diagram-text) !important;
+}
+
+.markdown-body .mermaid :where(.edgePath path, .flowchart-link, .relationshipLine) {
+  stroke: var(--theme-diagram-line) !important;
+}
+
+.markdown-body .mermaid .cluster rect {
+  fill: var(--theme-table-surface) !important;
+  stroke: var(--theme-border) !important;
+}
+
+.markdown-body .mermaid :where(.edgeLabel, .labelBkg) {
+  color: var(--theme-diagram-text) !important;
+  fill: var(--theme-diagram-label-surface) !important;
+  background: var(--theme-diagram-label-surface) !important;
 }
 
 .markdown-body .mermaid svg {
@@ -135,6 +237,35 @@ body {
 
   .markdown-body :where(pre, table, .mermaid, .embedded-svg-container) {
     scrollbar-width: thin;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-canvas: #111827;
+    --theme-text: #e5e7eb;
+    --theme-muted: #a8b3c4;
+    --theme-accent: #7db4ff;
+    --theme-link: #91c4ff;
+    --theme-border: #44516a;
+    --theme-quote-surface: #1b2536;
+    --theme-table-surface: #182235;
+    --theme-diagram-surface: #182235;
+    --theme-code-text: #f8fafc;
+    --theme-code-surface: #070f1c;
+    --theme-focus: #8dc2ff;
+    --theme-heading-on-accent: #07111f;
+    --theme-diagram-text: #e5e7eb;
+    --theme-diagram-node-surface: #202d43;
+    --theme-diagram-node-border: #7db4ff;
+    --theme-diagram-line: #93a4ba;
+    --theme-diagram-label-surface: #182235;
+    --theme-syntax-comment: #9aa9bd;
+    --theme-syntax-keyword: #f58ac3;
+    --theme-syntax-string: #a7db78;
+    --theme-syntax-number: #d6a6ff;
+    --theme-syntax-title: #7cc7ff;
+    --theme-syntax-meta: #ffd166;
   }
 }
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -4857,6 +4857,63 @@ body:hover::-webkit-scrollbar,
   box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.15);
 }
 
+.theme-select:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 3px;
+}
+
+.theme-sampler-settings {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.theme-sampler-settings.hidden {
+  display: none;
+}
+
+.theme-sampler-control {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.theme-sampler-control > label {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.theme-sampler-preview {
+  min-width: 0;
+}
+
+.theme-sampler-frame {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  height: 440px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+#theme-field {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 480px) {
+  .theme-sampler-settings {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .theme-sampler-frame {
+    height: 650px;
+  }
+}
+
 #theme-field select {
   width: 100%;
   padding: 10px 34px 10px 14px;
@@ -4877,6 +4934,11 @@ body:hover::-webkit-scrollbar,
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.15);
+}
+
+#theme-field .theme-select:focus-visible {
+  outline: 2px solid var(--primary-light);
+  outline-offset: 3px;
 }
 
 /* ===== API management ===== */

--- a/public/js/admin-detail.js
+++ b/public/js/admin-detail.js
@@ -21,6 +21,7 @@
   const statusDisplay = document.getElementById('status-display');
   const pageDataElement = document.getElementById('page-data');
   const renderedPreview = document.getElementById('rendered-preview');
+  const themeSelect = document.getElementById('edit-theme');
   const adminTime = window.AdminTime;
   const customPasswordPattern = /^[A-Za-z0-9!@#$%^&*()_+\-=.,?~]{4,12}$/;
   const customPasswordError = '自定义密码必须为 4–12 位，仅可包含英文字母、数字及 !@#$%^&*()_+-=.,?~';
@@ -80,6 +81,10 @@
     expiresHint.className = 'field-hint';
     resetPasswordVisibility();
     contentTextarea.value = originalData.htmlContent || '';
+    if (themeSelect) {
+      themeSelect.value = originalData.markdownTheme || 'bytedance';
+      if (window.ThemeSampler) window.ThemeSampler.updateForSelect(themeSelect);
+    }
     updateProtectionHint(Boolean(originalData.isProtected));
     updatePasswordInputVisibility();
   }
@@ -242,8 +247,6 @@
       isProtected: protectedCheckbox.checked,
       expiresAt
     };
-    const themeSelect = document.getElementById('edit-theme');
-
     if (themeSelect) payload.markdownTheme = themeSelect.value;
     if (protectedCheckbox.checked && customPassword) payload.password = customPassword;
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -464,7 +464,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const themeSelect = document.getElementById('markdown-theme');
-    if (themeSelect) themeSelect.value = 'bytedance';
+    if (themeSelect) {
+      themeSelect.value = creatorThemePreference;
+      if (window.ThemeSampler) window.ThemeSampler.updateForSelect(themeSelect);
+    }
 
     draftVersion = 0;
     userCustomPassword = '';
@@ -634,7 +637,45 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const markdownThemeSelect = document.getElementById('markdown-theme');
-  if (markdownThemeSelect) markdownThemeSelect.addEventListener('change', markDraftDirty);
+  const creatorThemePreferenceKey = 'quickshare:creator-markdown-theme';
+
+  function resolveCreatorThemeId(value) {
+    if (!markdownThemeSelect) return 'bytedance';
+
+    return Array.from(markdownThemeSelect.options).some(option => option.value === value)
+      ? value
+      : 'bytedance';
+  }
+
+  function readCreatorThemePreference() {
+    try {
+      return resolveCreatorThemeId(window.localStorage.getItem(creatorThemePreferenceKey));
+    } catch (error) {
+      return 'bytedance';
+    }
+  }
+
+  function writeCreatorThemePreference(value) {
+    try {
+      window.localStorage.setItem(creatorThemePreferenceKey, value);
+    } catch (error) {
+      // Browser storage is optional convenience state.
+    }
+  }
+
+  let creatorThemePreference = readCreatorThemePreference();
+
+  if (markdownThemeSelect) {
+    markdownThemeSelect.value = creatorThemePreference;
+    if (window.ThemeSampler) window.ThemeSampler.updateForSelect(markdownThemeSelect);
+
+    markdownThemeSelect.addEventListener('change', () => {
+      creatorThemePreference = resolveCreatorThemeId(markdownThemeSelect.value);
+      markdownThemeSelect.value = creatorThemePreference;
+      writeCreatorThemePreference(creatorThemePreference);
+      markDraftDirty();
+    });
+  }
 
   syncPasswordSettings();
 

--- a/public/js/theme-sampler.js
+++ b/public/js/theme-sampler.js
@@ -1,0 +1,133 @@
+(function () {
+  const baselineHref = '/css/markdown-theme-baseline.css';
+  const fallbackSignatureHref = '/css/markdown-bytedance.css';
+  const trustedSignaturePattern = /^\/css\/markdown-[a-z]+\.css$/;
+  const compactStyles = `
+    :root { --theme-reading-padding: 14px; }
+    html, body { min-height: 0; }
+    body { overflow-x: hidden; }
+    .markdown-body.theme-sampler-body {
+      width: 100%;
+      max-width: none;
+      padding: 14px;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    .theme-sampler-body :where(h1, h2, p, ul, blockquote, pre, table, figure, hr) {
+      margin-top: 0;
+      margin-bottom: 8px;
+    }
+    .theme-sampler-body h1 {
+      max-width: 100%;
+      margin: 0 0 10px;
+      padding: 8px 12px;
+      font-size: 20px;
+      line-height: 1.2;
+      text-align: left;
+    }
+    .theme-sampler-body h2 {
+      max-width: 100%;
+      margin: 0 0 7px;
+      padding: 5px 8px;
+      font-size: 15px;
+      line-height: 1.25;
+    }
+    .theme-sampler-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+    .theme-sampler-body :where(ul, ol) { padding-left: 20px; }
+    .theme-sampler-body blockquote { padding: 7px 9px 7px 14px; }
+    .theme-sampler-body pre { padding: 8px; font-size: 11px; }
+    .theme-sampler-body table { width: 100%; }
+    .theme-sampler-body :where(th, td) { padding: 5px 7px; }
+    .theme-sampler-assets {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      align-items: start;
+    }
+    .theme-sampler-image { display: grid; gap: 3px; }
+    .theme-sampler-image svg { width: 100%; height: 54px; }
+    .theme-sampler-image figcaption { color: var(--theme-muted); font-size: 11px; }
+    .theme-sampler-diagram {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 28px minmax(0, 1fr);
+      align-items: center;
+      gap: 6px;
+      padding: 8px;
+      overflow: hidden;
+      color: var(--theme-diagram-text);
+      background: var(--theme-diagram-surface);
+      border: 1px solid var(--theme-border);
+      border-radius: 8px;
+    }
+    .theme-sampler-diagram span {
+      padding: 6px;
+      text-align: center;
+      background: var(--theme-diagram-node-surface);
+      border: 1px solid var(--theme-diagram-node-border);
+      border-radius: 6px;
+    }
+    .theme-sampler-diagram i { height: 2px; background: var(--theme-diagram-line); }
+    @media (max-width: 420px) {
+      .theme-sampler-diagram { grid-template-columns: minmax(0, 1fr); }
+      .theme-sampler-diagram i { width: 2px; height: 14px; margin-inline: auto; }
+    }
+  `;
+
+  function trustedSignatureHref(option) {
+    const candidate = option && option.dataset.signatureHref;
+    return trustedSignaturePattern.test(candidate || '') ? candidate : fallbackSignatureHref;
+  }
+
+  function samplerDocument(content, signatureHref) {
+    return `<!DOCTYPE html>
+      <html lang="zh-CN">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <link rel="stylesheet" href="${baselineHref}">
+          <link rel="stylesheet" href="${signatureHref}">
+          <style>${compactStyles}</style>
+        </head>
+        <body>${content}</body>
+      </html>`;
+  }
+
+  function update(root) {
+    if (!root) return;
+
+    const select = document.getElementById(root.dataset.selectId);
+    const frame = root.querySelector('[data-theme-sampler-frame]');
+    const template = root.querySelector('[data-theme-sampler-template]');
+    const option = select && select.selectedOptions[0];
+
+    if (!select || !frame || !template || !option) return;
+
+    const label = option.dataset.themeLabel || option.textContent.trim();
+    const accessibleName = `${label}主题样例`;
+    root.setAttribute('aria-label', accessibleName);
+    frame.title = accessibleName;
+    frame.srcdoc = samplerDocument(template.innerHTML.trim(), trustedSignatureHref(option));
+  }
+
+  function bind(root) {
+    const select = root && document.getElementById(root.dataset.selectId);
+    if (!select) return;
+
+    select.addEventListener('change', function () { update(root); });
+    update(root);
+  }
+
+  function updateForSelect(select) {
+    if (!select) return;
+    const root = Array.from(document.querySelectorAll('[data-theme-sampler]'))
+      .find(candidate => candidate.dataset.selectId === select.id);
+    update(root);
+  }
+
+  Array.from(document.querySelectorAll('[data-theme-sampler]')).forEach(bind);
+  window.ThemeSampler = { updateForSelect };
+})();

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -160,3 +160,6 @@
 
 - When a route requires a signed session, same-origin request, and CSRF token, build its regression test from the rendered page token instead of bypassing one layer of the contract.
 - A `403` from an incomplete test request is harness evidence, not a product regression; correct the request and rerun the unchanged product assertion.
+## 2026-07-23 — Bind release evidence to the candidate head
+
+- Before posting completion evidence, read the current PR head SHA and its successful CI run directly from GitHub; do not reuse a run ID from an earlier ticket, even when both runs passed the same workflow.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,7 @@ Status: Phases 0–3 deployed on 2026-07-15; the representative WP8 traffic base
 
 ## Issue #11 — Markdown Theme Catalog, shared baseline, and ByteDance tracer (2026-07-22)
 
-Status: independent review findings remediated and local verification complete on `codex/markdown-theme-catalog`; post-remediation review and remote PostgreSQL CI remain pending. Parent Issue #10 remains unreleased.
+Status: complete on `codex/markdown-theme-catalog`; Issue #11 is closed after independent review and remote PostgreSQL CI. Parent Issue #10 remains unreleased.
 
 Confirmed boundaries:
 
@@ -22,8 +22,8 @@ Plan:
 - [x] Implement the Catalog module and replace duplicated server/template theme lists with its safe projection.
 - [x] Add the shared reading baseline and refactor ByteDance into a signature-only, system-font, light/dark stylesheet without malformed glyphs or broad blur.
 - [x] Run focused tests, the complete Node suite, syntax/diff checks, and real-browser ByteDance acceptance at 375/768/1440 plus a 320 CSS px reflow boundary equivalent to 640 px at 200% browser zoom.
-- [ ] Run the GitHub CI job against its isolated PostgreSQL 17 `quickshare_test` service.
-- [ ] Run Standards and Spec review, remediate findings, commit and push the #11 slice on the integration branch, attach evidence, and close #11 only after independent verification.
+- [x] Run the GitHub CI job against its isolated PostgreSQL 17 `quickshare_test` service.
+- [x] Run Standards and Spec review, remediate findings, commit and push the #11 slice on the integration branch, attach evidence, and close #11 only after independent verification.
 
 Verify:
 
@@ -55,6 +55,7 @@ Independent review remediation:
 - Preservation coverage: the theme-only admin test now retains non-default password hash/ciphertext, protection, expiration, Favorite Share state, view count, content, title, and description; the Share API invalid-value path is covered.
 - Standards: obsolete `MARKDOWN_THEMES`/`resolveTheme` forwarding exports were removed and the new test helper uses the Share domain term.
 - Legacy compatibility follow-up: shared syntax roles are optional signature enhancements and otherwise inherit the active code foreground. GitHub, Apple, and Notion explicitly retain their existing dark text on light fenced-code surfaces in both system appearances until Issues #12/#13 migrate them; cache-busted browser readback confirmed GitHub `#24292f` on `#f6f8fa` with no fixed highlight stylesheet.
+- Final gates: independent Standards Review and Spec Review both returned 0 findings at `ae6a798`; GitHub Actions run `29935833579` passed Node 24 and PostgreSQL 17; completion evidence was attached to Issue #11 before it was closed.
 
 ## Site identity icon replacement design (2026-07-22)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -38,7 +38,7 @@ Verify:
 Local verification:
 
 - TDD: the Catalog module and shared baseline each began with a failing contract; the empty admin write also failed as `null` before normalization was corrected.
-- Tests: the post-review focused Catalog/renderer/HTTP slice passes 20/20; the complete Node suite passes 191/191; changed JavaScript syntax and `git diff --check` pass.
+- Tests: the post-review focused Catalog/renderer/HTTP slice passes 21/21; the complete Node suite passes 192/192; changed JavaScript syntax and `git diff --check` pass.
 - Browser geometry: light and dark ByteDance pass at 375, 768, and 1440 px; the reading column is bounded at 900 px and document `scrollWidth` equals `clientWidth` at every width.
 - Narrow reflow: at 320 CSS px the page remains 305/305 px with table, code, and Mermaid overflow contained internally; the table alone scrolls 280 px inside a 271 px container.
 - Visual/accessibility: representative light and dark body, link, quote, code, heading, and focus colors meet the measured contrast boundary; keyboard focus exposes a solid 3 px theme-aware outline.
@@ -54,6 +54,7 @@ Independent review remediation:
 - New-write consistency: admin clone resolves null, `random`, and invalid legacy Markdown values to ByteDance and writes null for non-Markdown clones.
 - Preservation coverage: the theme-only admin test now retains non-default password hash/ciphertext, protection, expiration, Favorite Share state, view count, content, title, and description; the Share API invalid-value path is covered.
 - Standards: obsolete `MARKDOWN_THEMES`/`resolveTheme` forwarding exports were removed and the new test helper uses the Share domain term.
+- Legacy compatibility follow-up: shared syntax roles are optional signature enhancements and otherwise inherit the active code foreground. GitHub, Apple, and Notion explicitly retain their existing dark text on light fenced-code surfaces in both system appearances until Issues #12/#13 migrate them; cache-busted browser readback confirmed GitHub `#24292f` on `#f6f8fa` with no fixed highlight stylesheet.
 
 ## Site identity icon replacement design (2026-07-22)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,6 +2,50 @@
 
 Status: Phases 0–3 deployed on 2026-07-15; the representative WP8 traffic baseline remains in passive collection.
 
+## Issue #11 — Markdown Theme Catalog, shared baseline, and ByteDance tracer (2026-07-22)
+
+Status: implementation and local verification complete on `codex/markdown-theme-catalog`; independent review and remote PostgreSQL CI remain pending. Parent Issue #10 remains unreleased.
+
+Confirmed boundaries:
+
+- One server-owned Catalog is authoritative for stable IDs, labels, order, trusted local signature paths, and light/dark wrapper metadata.
+- The homepage, admin editor, request normalization, and renderer consume Catalog projections instead of maintaining option lists or asset maps.
+- One independently loaded Theme Reading Baseline owns responsive containment, focus visibility, image/task normalization, and bounded tables, code, and diagrams.
+- ByteDance is the first migrated end-to-end signature and deterministic fallback. GitHub, Apple, Notion, and Claude remain operational until Issues #12 and #13 migrate them.
+- The persisted text field and every existing API response shape remain unchanged. The disposable `prototypes/` tree is neither read nor committed.
+
+Plan:
+
+- [x] Add failing Catalog contract tests for identity, order, safe projection, local assets, paired appearance metadata, immutability, and ByteDance fallback.
+- [x] Add failing renderer tests proving baseline-before-signature loading, trusted appearance metadata, unknown-value safety, and conditional Mermaid/highlight assets.
+- [x] Add failing HTTP tests proving Catalog-driven homepage/admin options, ByteDance create/preview/public behavior, unknown normalization, and read-only fallback for invalid stored values.
+- [x] Implement the Catalog module and replace duplicated server/template theme lists with its safe projection.
+- [x] Add the shared reading baseline and refactor ByteDance into a signature-only, system-font, light/dark stylesheet without malformed glyphs or broad blur.
+- [x] Run focused tests, the complete Node suite, syntax/diff checks, and real-browser ByteDance acceptance at 375/768/1440 plus a 320 CSS px reflow boundary equivalent to 640 px at 200% browser zoom.
+- [ ] Run the GitHub CI job against its isolated PostgreSQL 17 `quickshare_test` service.
+- [ ] Run Standards and Spec review, remediate findings, commit and push the #11 slice on the integration branch, attach evidence, and close #11 only after independent verification.
+
+Verify:
+
+1. Catalog -> five existing IDs are unique and ordered, labels/assets/appearance metadata are trusted, and every invalid value resolves to ByteDance.
+2. Projection -> homepage and admin render options from the same server projection; browser strings cannot become stylesheet URLs.
+3. Renderer -> baseline loads before the resolved signature; wrapper canvas/theme-color follows trusted light/dark metadata; optional runtimes remain content-conditional.
+4. ByteDance -> create, preview, persistence, metadata, admin update, and public rendering preserve its ID and recognizable blue/teal signature.
+5. Resilience -> signature failure leaves readable contained content; invalid stored values render ByteDance without rewriting the row during a read.
+6. Compatibility -> database/API shapes and non-Markdown flows are unchanged; the four pending legacy signatures remain usable.
+7. Visual -> ByteDance light/dark has no page-level overflow, passes representative contrast/focus checks, and reflows at required widths and 200% zoom.
+
+Local verification:
+
+- TDD: the Catalog module and shared baseline each began with a failing contract; the empty admin write also failed as `null` before normalization was corrected.
+- Tests: the focused Catalog/renderer/HTTP slice passes 18/18; the complete Node suite passes 189/189; changed JavaScript syntax and `git diff --check` pass.
+- Browser geometry: light and dark ByteDance pass at 375, 768, and 1440 px; the reading column is bounded at 900 px and document `scrollWidth` equals `clientWidth` at every width.
+- Narrow reflow: at 320 CSS px the page remains 305/305 px with table, code, and Mermaid overflow contained internally; the table alone scrolls 280 px inside a 271 px container.
+- Visual/accessibility: representative light and dark body, link, quote, code, heading, and focus colors meet the measured contrast boundary; keyboard focus exposes a solid 3 px theme-aware outline.
+- Failure resilience: aborting `/css/markdown-bytedance.css` produces `TypeError: Failed to fetch`, while the independent baseline keeps readable content and 360/360 px page geometry with 326 px contained table, code, and Mermaid regions.
+- Resources: the real mixed-content sample loads one baseline, one trusted ByteDance signature, and only the content-triggered Highlight.js and Mermaid resources; plain Markdown remains covered by a no-optional-runtime contract test.
+- PostgreSQL: no safe local `_test` instance is running; the repository CI workflow provides PostgreSQL 17 and remains the required remote gate after push.
+
 ## Site identity icon replacement design (2026-07-22)
 
 Status: complete; asset commit `e2e46e0` is pushed and production deployment `dpl_C9G92ugidV333Rcz2L3vxtfs4YEv` was verified on 2026-07-22.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -57,6 +57,32 @@ Independent review remediation:
 - Legacy compatibility follow-up: shared syntax roles are optional signature enhancements and otherwise inherit the active code foreground. GitHub, Apple, and Notion explicitly retain their existing dark text on light fenced-code surfaces in both system appearances until Issues #12/#13 migrate them; cache-busted browser readback confirmed GitHub `#24292f` on `#f6f8fa` with no fixed highlight stylesheet.
 - Final gates: independent Standards Review and Spec Review both returned 0 findings at `ae6a798`; GitHub Actions run `29935833579` passed Node 24 and PostgreSQL 17; completion evidence was attached to Issue #11 before it was closed.
 
+## Issues #12–#19 — Twelve-theme Catalog, Sampler, and release (2026-07-23)
+
+Status: Issues #12–#18 are implemented and integrated on `codex/markdown-theme-catalog`; Issue #19 release gates are in progress. The disposable `prototypes/` tree remains untracked and excluded.
+
+- [x] Migrate GitHub and Apple to the shared baseline with system light/dark appearances.
+- [x] Migrate Notion and Claude, remove theme-owned remote fonts, and align real task-list output with the baseline.
+- [x] Add the fixed read-only Theme Sampler to create and admin edit flows.
+- [x] Add validated homepage-only Creator Theme Preference; admin edit remains driven by the stored Share theme.
+- [x] Add Raycast, Google, Tesla, Airbnb, Bugatti, Linear, and PlayStation signatures in the formal Catalog order.
+- [x] Preserve preview/create/API/metadata/admin/public round trips, invalid-value fallback, and non-Markdown compatibility.
+- [x] Run the integrated focused suite, full suite, syntax checks, diff checks, and final real-browser matrices.
+- [ ] Push the release candidate, pass Node 24 plus PostgreSQL 17 CI, and verify Vercel Preview.
+- [ ] Attach evidence and close Issues #12–#18; complete Issue #19 only after production release and live verification.
+
+Integrated verification:
+
+- Catalog order is ByteDance, GitHub, Apple, Notion, Claude, Raycast, Google, Tesla, Airbnb, Bugatti, Linear, PlayStation; the browser projection carries only stable ID, label, and trusted local signature path.
+- Focused Catalog/theme/Sampler tests pass 58/58; the complete Node suite passes 237/237. Changed JavaScript syntax and `git diff --check` pass.
+- The Sampler outer-page matrix passes all 72 combinations: twelve themes × light/dark × 375/768/1440. Every combination keeps the page contained, loads the selected local signature, preserves the accessible name, and keeps the iframe outside sequential focus.
+- The representative rendered-Markdown matrix passes the same 72 combinations with bounded reading width, contained code/table/diagram surfaces, one baseline plus one signature, a non-transparent canvas, and a visible 3px focus outline.
+- Direct 375px Sampler checks pass all twelve themes in both appearances: fixed content fits the 648px frame, the diagram reflows vertically, and no page-level horizontal overflow appears. A 375px boundary is stricter than the 384 CSS px reflow equivalent of a 768px viewport at 200% zoom.
+- Real browser preference checks prove immediate switching makes zero full-preview requests and does not mutate editor content; a valid homepage preference survives reload, an invalid stored value falls back to ByteDance, and admin ignores the homepage preference while retaining the Share's stored theme.
+- Visual contact sheets for all twelve light and dark signatures were inspected from real Chromium output. They are temporary acceptance artifacts and are not part of the repository.
+- The first integrated full run reproduced the existing interrupted-request timing flake (`6 !== 7`); an isolated rerun and the unchanged second full run passed, so no unrelated performance code was modified.
+- Final Standards Review found no hard violations; its only low-priority note was deliberate helper duplication that keeps each vertical ticket independently executable. Final Spec Review returned 0 findings against the formal Catalog, baseline, Sampler, compatibility, and Prototype-exclusion requirements.
+
 ## Site identity icon replacement design (2026-07-22)
 
 Status: complete; asset commit `e2e46e0` is pushed and production deployment `dpl_C9G92ugidV333Rcz2L3vxtfs4YEv` was verified on 2026-07-22.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -59,7 +59,7 @@ Independent review remediation:
 
 ## Issues #12–#19 — Twelve-theme Catalog, Sampler, and release (2026-07-23)
 
-Status: Issues #12–#18 are implemented and integrated on `codex/markdown-theme-catalog`; Issue #19 release gates are in progress. The disposable `prototypes/` tree remains untracked and excluded.
+Status: Issues #12–#18 are implemented, remotely verified, and closed; Issue #19 production release gates are in progress. The disposable `prototypes/` tree remains untracked and excluded.
 
 - [x] Migrate GitHub and Apple to the shared baseline with system light/dark appearances.
 - [x] Migrate Notion and Claude, remove theme-owned remote fonts, and align real task-list output with the baseline.
@@ -68,8 +68,9 @@ Status: Issues #12–#18 are implemented and integrated on `codex/markdown-theme
 - [x] Add Raycast, Google, Tesla, Airbnb, Bugatti, Linear, and PlayStation signatures in the formal Catalog order.
 - [x] Preserve preview/create/API/metadata/admin/public round trips, invalid-value fallback, and non-Markdown compatibility.
 - [x] Run the integrated focused suite, full suite, syntax checks, diff checks, and final real-browser matrices.
-- [ ] Push the release candidate, pass Node 24 plus PostgreSQL 17 CI, and verify Vercel Preview.
-- [ ] Attach evidence and close Issues #12–#18; complete Issue #19 only after production release and live verification.
+- [x] Push the release candidate, pass Node 24 plus PostgreSQL 17 CI, and verify Vercel Preview.
+- [x] Attach evidence and close Issues #12–#18.
+- [ ] Complete Issue #19 only after production release and live verification.
 
 Integrated verification:
 
@@ -82,6 +83,7 @@ Integrated verification:
 - Visual contact sheets for all twelve light and dark signatures were inspected from real Chromium output. They are temporary acceptance artifacts and are not part of the repository.
 - The first integrated full run reproduced the existing interrupted-request timing flake (`6 !== 7`); an isolated rerun and the unchanged second full run passed, so no unrelated performance code was modified.
 - Final Standards Review found no hard violations; its only low-priority note was deliberate helper duplication that keeps each vertical ticket independently executable. Final Spec Review returned 0 findings against the formal Catalog, baseline, Sampler, compatibility, and Prototype-exclusion requirements.
+- GitHub Actions run `29941287814` passed Node 24 and PostgreSQL 17 for candidate `dad1679`. The protected Vercel Preview was invoked through authenticated tooling: homepage, PlayStation preview API, shared baseline, PlayStation signature, and Sampler script all returned 200. Preview-only branch configuration disables auth and uses an isolated session secret; Production configuration was not changed.
 
 ## Site identity icon replacement design (2026-07-22)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,7 @@ Status: Phases 0–3 deployed on 2026-07-15; the representative WP8 traffic base
 
 ## Issue #11 — Markdown Theme Catalog, shared baseline, and ByteDance tracer (2026-07-22)
 
-Status: implementation and local verification complete on `codex/markdown-theme-catalog`; independent review and remote PostgreSQL CI remain pending. Parent Issue #10 remains unreleased.
+Status: independent review findings remediated and local verification complete on `codex/markdown-theme-catalog`; post-remediation review and remote PostgreSQL CI remain pending. Parent Issue #10 remains unreleased.
 
 Confirmed boundaries:
 
@@ -38,13 +38,22 @@ Verify:
 Local verification:
 
 - TDD: the Catalog module and shared baseline each began with a failing contract; the empty admin write also failed as `null` before normalization was corrected.
-- Tests: the focused Catalog/renderer/HTTP slice passes 18/18; the complete Node suite passes 189/189; changed JavaScript syntax and `git diff --check` pass.
+- Tests: the post-review focused Catalog/renderer/HTTP slice passes 20/20; the complete Node suite passes 191/191; changed JavaScript syntax and `git diff --check` pass.
 - Browser geometry: light and dark ByteDance pass at 375, 768, and 1440 px; the reading column is bounded at 900 px and document `scrollWidth` equals `clientWidth` at every width.
 - Narrow reflow: at 320 CSS px the page remains 305/305 px with table, code, and Mermaid overflow contained internally; the table alone scrolls 280 px inside a 271 px container.
 - Visual/accessibility: representative light and dark body, link, quote, code, heading, and focus colors meet the measured contrast boundary; keyboard focus exposes a solid 3 px theme-aware outline.
 - Failure resilience: aborting `/css/markdown-bytedance.css` produces `TypeError: Failed to fetch`, while the independent baseline keeps readable content and 360/360 px page geometry with 326 px contained table, code, and Mermaid regions.
 - Resources: the real mixed-content sample loads one baseline, one trusted ByteDance signature, and only the content-triggered Highlight.js and Mermaid resources; plain Markdown remains covered by a no-optional-runtime contract test.
 - PostgreSQL: no safe local `_test` instance is running; the repository CI workflow provides PostgreSQL 17 and remains the required remote gate after push.
+
+Independent review remediation:
+
+- Preset-aware technical content: the baseline now defines the complete shared canvas/text/muted/accent/link/border/quotation/table/diagram/code/focus/heading-on-accent contract plus syntax and Mermaid roles. ByteDance supplies light/dark values; Markdown no longer downloads fixed Atom One Dark CSS.
+- Adaptive runtimes: Highlight.js consumes local token-aware styles, while Mermaid reads the resolved CSS tokens at initialization, preserves diagram source, and rerenders when system appearance changes.
+- Browser readback: ByteDance Mermaid node fill/stroke/text changed from `#e8f3ff / #1677ff / #29435d` to `#1d3853 / #5ca4ff / #d8e5f3` after a live light-to-dark preference change; the diagram remained rendered and page geometry stayed contained. The network contained no highlight stylesheet request.
+- New-write consistency: admin clone resolves null, `random`, and invalid legacy Markdown values to ByteDance and writes null for non-Markdown clones.
+- Preservation coverage: the theme-only admin test now retains non-default password hash/ciphertext, protection, expiration, Favorite Share state, view count, content, title, and description; the Share API invalid-value path is covered.
+- Standards: obsolete `MARKDOWN_THEMES`/`resolveTheme` forwarding exports were removed and the new test helper uses the Share domain term.
 
 ## Site identity icon replacement design (2026-07-22)
 

--- a/test/content-renderer.test.js
+++ b/test/content-renderer.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const { renderHtml, renderMarkdown } = require('../utils/contentRenderer');
+const { resolveMarkdownTheme } = require('../utils/markdownThemeCatalog');
 
 test('renderHtml loads highlighting only for partial HTML with a preformatted code block', () => {
   const plain = renderHtml('<p>Plain partial HTML</p>');
@@ -52,4 +53,40 @@ test('renderMarkdown loads Mermaid only when a mermaid block exists', async () =
 
   assert.match(html, /mermaid\.min\.js/);
   assert.doesNotMatch(html, /highlight\.min\.js/);
+});
+
+test('renderMarkdown loads the shared baseline before one trusted signature', async () => {
+  const html = await renderMarkdown('# Catalog contract', 'github');
+  const baselinePosition = html.indexOf('/css/markdown-theme-baseline.css');
+  const signaturePosition = html.indexOf('/css/markdown-github.css');
+
+  assert.ok(baselinePosition >= 0);
+  assert.ok(signaturePosition > baselinePosition);
+  assert.equal((html.match(/markdown-theme-baseline\.css/g) || []).length, 1);
+  assert.equal((html.match(/markdown-github\.css/g) || []).length, 1);
+  assert.match(html, /<html[^>]+data-markdown-theme="github"/);
+});
+
+test('renderMarkdown derives light and dark wrapper metadata from the resolved Catalog entry', async () => {
+  const theme = resolveMarkdownTheme('bytedance');
+  const html = await renderMarkdown('# Adaptive ByteDance', 'bytedance');
+
+  assert.match(
+    html,
+    new RegExp(`<meta name="theme-color" content="${theme.appearances.light.themeColor}" media="\\(prefers-color-scheme: light\\)">`)
+  );
+  assert.match(
+    html,
+    new RegExp(`<meta name="theme-color" content="${theme.appearances.dark.themeColor}" media="\\(prefers-color-scheme: dark\\)">`)
+  );
+  assert.match(html, new RegExp(`--theme-canvas: ${theme.appearances.light.canvas}`));
+  assert.match(html, new RegExp(`--theme-canvas: ${theme.appearances.dark.canvas}`));
+});
+
+test('renderMarkdown never reflects an invalid theme into an asset URL', async () => {
+  const html = await renderMarkdown('# Safe fallback', '../../admin-secret');
+
+  assert.match(html, /data-markdown-theme="bytedance"/);
+  assert.match(html, /href="\/css\/markdown-bytedance\.css"/);
+  assert.doesNotMatch(html, /admin-secret/);
 });

--- a/test/content-renderer.test.js
+++ b/test/content-renderer.test.js
@@ -43,7 +43,7 @@ test('renderMarkdown loads highlight assets only for non-mermaid code blocks', a
   const html = await renderMarkdown(`${fence}js\nconsole.log('hello');\n${fence}`);
 
   assert.match(html, /highlight\.min\.js/);
-  assert.match(html, /atom-one-dark\.min\.css/);
+  assert.doesNotMatch(html, /atom-one-dark\.min\.css/);
   assert.doesNotMatch(html, /mermaid\.min\.js/);
 });
 
@@ -52,6 +52,9 @@ test('renderMarkdown loads Mermaid only when a mermaid block exists', async () =
   const html = await renderMarkdown(`${fence}mermaid\ngraph TD\nA-->B\n${fence}`);
 
   assert.match(html, /mermaid\.min\.js/);
+  assert.match(html, /getPropertyValue\(name\)/);
+  assert.match(html, /--theme-diagram-node-surface/);
+  assert.match(html, /appearanceQuery\.addEventListener\('change', rerenderForAppearance\)/);
   assert.doesNotMatch(html, /highlight\.min\.js/);
 });
 

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -18,6 +18,8 @@ const EXPECTED_THEMES = [
   ['notion', 'Notion 笔记'],
   ['claude', 'Claude 暖调'],
   ['raycast', 'Raycast 专注'],
+  ['google', 'Google Material'],
+  ['airbnb', 'Airbnb 暖居'],
   ['linear', 'Linear 精密']
 ];
 

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -16,7 +16,9 @@ const EXPECTED_THEMES = [
   ['github', 'GitHub 经典'],
   ['apple', 'Apple 极简'],
   ['notion', 'Notion 笔记'],
-  ['claude', 'Claude 暖调']
+  ['claude', 'Claude 暖调'],
+  ['raycast', 'Raycast 专注'],
+  ['linear', 'Linear 精密']
 ];
 
 test('Catalog owns the ordered existing theme identities and trusted assets', () => {

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -110,8 +110,8 @@ test('shared baseline owns reading containment while ByteDance owns only its sig
   assert.doesNotMatch(bytedance, /@import|fonts\.googleapis\.com|filter:\s*blur|content:\s*["']u[0-9a-f]{4}/i);
 });
 
-test('pending legacy signatures keep readable fenced-code foregrounds during baseline migration', () => {
-  for (const id of ['github', 'apple', 'notion']) {
+test('the pending Notion signature keeps a readable fenced-code foreground during baseline migration', () => {
+  for (const id of ['notion']) {
     const signature = fs.readFileSync(
       path.join(__dirname, `../public/css/markdown-${id}.css`),
       'utf8'

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -19,7 +19,9 @@ const EXPECTED_THEMES = [
   ['claude', 'Claude 暖调'],
   ['raycast', 'Raycast 专注'],
   ['google', 'Google Material'],
+  ['tesla', 'Tesla 黑白'],
   ['airbnb', 'Airbnb 暖居'],
+  ['bugatti', 'Bugatti 蓝曜'],
   ['linear', 'Linear 精密']
 ];
 

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -77,6 +77,31 @@ test('shared baseline owns reading containment while ByteDance owns only its sig
   assert.match(baseline, /\.markdown-body\s+:where\(pre, table, \.mermaid/);
   assert.match(baseline, /:focus-visible/);
   assert.match(baseline, /@media \(max-width:\s*480px\)/);
+  for (const token of [
+    'canvas',
+    'text',
+    'muted',
+    'accent',
+    'link',
+    'border',
+    'quote-surface',
+    'table-surface',
+    'diagram-surface',
+    'diagram-text',
+    'diagram-node-surface',
+    'diagram-node-border',
+    'diagram-line',
+    'diagram-label-surface',
+    'code-text',
+    'code-surface',
+    'focus',
+    'heading-on-accent'
+  ]) {
+    assert.match(baseline, new RegExp(`--theme-${token}:`));
+  }
+  assert.match(baseline, /@media \(prefers-color-scheme:\s*dark\)/);
+  assert.match(baseline, /\.hljs-keyword/);
+  assert.match(baseline, /\.mermaid :where\(\.node rect/);
   assert.doesNotMatch(baseline, /#1677ff|#05d4cd/);
 
   assert.match(bytedance, /--theme-accent:\s*#1677ff/i);

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -109,14 +109,3 @@ test('shared baseline owns reading containment while ByteDance owns only its sig
   assert.match(bytedance, /@media \(prefers-color-scheme:\s*dark\)/);
   assert.doesNotMatch(bytedance, /@import|fonts\.googleapis\.com|filter:\s*blur|content:\s*["']u[0-9a-f]{4}/i);
 });
-
-test('the pending Notion signature keeps a readable fenced-code foreground during baseline migration', () => {
-  for (const id of ['notion']) {
-    const signature = fs.readFileSync(
-      path.join(__dirname, `../public/css/markdown-${id}.css`),
-      'utf8'
-    );
-
-    assert.match(signature, /\.markdown-body pre\s*\{[^}]*color:\s*#[0-9a-f]{6}/is);
-  }
-});

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  DEFAULT_MARKDOWN_THEME_ID,
+  MARKDOWN_THEME_CATALOG,
+  getMarkdownThemeOptions,
+  resolveMarkdownTheme,
+  resolveMarkdownThemeId
+} = require('../utils/markdownThemeCatalog');
+
+const EXPECTED_THEMES = [
+  ['bytedance', 'ByteDance 蓝绿'],
+  ['github', 'GitHub 经典'],
+  ['apple', 'Apple 极简'],
+  ['notion', 'Notion 笔记'],
+  ['claude', 'Claude 暖调']
+];
+
+test('Catalog owns the ordered existing theme identities and trusted assets', () => {
+  assert.equal(DEFAULT_MARKDOWN_THEME_ID, 'bytedance');
+  assert.deepEqual(
+    MARKDOWN_THEME_CATALOG.map(({ id, label }) => [id, label]),
+    EXPECTED_THEMES
+  );
+  assert.equal(new Set(MARKDOWN_THEME_CATALOG.map(({ id }) => id)).size, EXPECTED_THEMES.length);
+  assert.equal(Object.isFrozen(MARKDOWN_THEME_CATALOG), true);
+
+  for (const theme of MARKDOWN_THEME_CATALOG) {
+    assert.equal(Object.isFrozen(theme), true);
+    assert.match(theme.signatureHref, /^\/css\/markdown-[a-z]+\.css$/);
+    assert.deepEqual(Object.keys(theme.appearances), ['light', 'dark']);
+
+    for (const appearance of Object.values(theme.appearances)) {
+      assert.match(appearance.canvas, /^#[0-9a-f]{6}$/i);
+      assert.match(appearance.themeColor, /^#[0-9a-f]{6}$/i);
+    }
+  }
+});
+
+test('Catalog exposes a minimal immutable selector projection', () => {
+  const options = getMarkdownThemeOptions();
+
+  assert.deepEqual(options, EXPECTED_THEMES.map(([id, label]) => ({ id, label })));
+  assert.equal(Object.isFrozen(options), true);
+  assert.equal(options.every(Object.isFrozen), true);
+  assert.equal('signatureHref' in options[0], false);
+  assert.equal('appearances' in options[0], false);
+});
+
+test('Catalog resolves every invalid or legacy request to ByteDance', () => {
+  for (const value of [undefined, null, '', 'random', 'legacy-theme', '../admin.css', {}, []]) {
+    assert.equal(resolveMarkdownThemeId(value), 'bytedance');
+    assert.equal(resolveMarkdownTheme(value).id, 'bytedance');
+  }
+
+  for (const [id] of EXPECTED_THEMES) {
+    assert.equal(resolveMarkdownThemeId(id), id);
+    assert.equal(resolveMarkdownTheme(id).id, id);
+  }
+});
+
+test('shared baseline owns reading containment while ByteDance owns only its signature', () => {
+  const baseline = fs.readFileSync(
+    path.join(__dirname, '../public/css/markdown-theme-baseline.css'),
+    'utf8'
+  );
+  const bytedance = fs.readFileSync(
+    path.join(__dirname, '../public/css/markdown-bytedance.css'),
+    'utf8'
+  );
+
+  assert.match(baseline, /box-sizing:\s*border-box/);
+  assert.match(baseline, /\.markdown-body\s*>\s*\*\s*\{[^}]*min-width:\s*0/s);
+  assert.match(baseline, /\.markdown-body\s+:where\(pre, table, \.mermaid/);
+  assert.match(baseline, /:focus-visible/);
+  assert.match(baseline, /@media \(max-width:\s*480px\)/);
+  assert.doesNotMatch(baseline, /#1677ff|#05d4cd/);
+
+  assert.match(bytedance, /--theme-accent:\s*#1677ff/i);
+  assert.match(bytedance, /--theme-secondary:\s*#008f8a/i);
+  assert.match(bytedance, /@media \(prefers-color-scheme:\s*dark\)/);
+  assert.doesNotMatch(bytedance, /@import|fonts\.googleapis\.com|filter:\s*blur|content:\s*["']u[0-9a-f]{4}/i);
+});

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -47,13 +47,19 @@ test('Catalog owns the ordered existing theme identities and trusted assets', ()
   }
 });
 
-test('Catalog exposes a minimal immutable selector projection', () => {
+test('Catalog exposes an immutable safe browser projection', () => {
   const options = getMarkdownThemeOptions();
 
-  assert.deepEqual(options, EXPECTED_THEMES.map(([id, label]) => ({ id, label })));
+  assert.deepEqual(
+    options,
+    EXPECTED_THEMES.map(([id, label]) => ({
+      id,
+      label,
+      signatureHref: `/css/markdown-${id}.css`
+    }))
+  );
   assert.equal(Object.isFrozen(options), true);
   assert.equal(options.every(Object.isFrozen), true);
-  assert.equal('signatureHref' in options[0], false);
   assert.equal('appearances' in options[0], false);
 });
 

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -22,7 +22,8 @@ const EXPECTED_THEMES = [
   ['tesla', 'Tesla 黑白'],
   ['airbnb', 'Airbnb 暖居'],
   ['bugatti', 'Bugatti 蓝曜'],
-  ['linear', 'Linear 精密']
+  ['linear', 'Linear 精密'],
+  ['playstation', 'PlayStation 蓝境']
 ];
 
 test('Catalog owns the ordered existing theme identities and trusted assets', () => {

--- a/test/markdown-theme-catalog.test.js
+++ b/test/markdown-theme-catalog.test.js
@@ -109,3 +109,14 @@ test('shared baseline owns reading containment while ByteDance owns only its sig
   assert.match(bytedance, /@media \(prefers-color-scheme:\s*dark\)/);
   assert.doesNotMatch(bytedance, /@import|fonts\.googleapis\.com|filter:\s*blur|content:\s*["']u[0-9a-f]{4}/i);
 });
+
+test('pending legacy signatures keep readable fenced-code foregrounds during baseline migration', () => {
+  for (const id of ['github', 'apple', 'notion']) {
+    const signature = fs.readFileSync(
+      path.join(__dirname, `../public/css/markdown-${id}.css`),
+      'utf8'
+    );
+
+    assert.match(signature, /\.markdown-body pre\s*\{[^}]*color:\s*#[0-9a-f]{6}/is);
+  }
+});

--- a/test/markdown-theme-google-airbnb.test.js
+++ b/test/markdown-theme-google-airbnb.test.js
@@ -1,0 +1,303 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'issue-16-theme-key';
+process.env.SESSION_SECRET = 'issue-16-theme-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const {
+  MARKDOWN_THEME_CATALOG,
+  getMarkdownThemeOptions,
+  resolveMarkdownTheme
+} = require('../utils/markdownThemeCatalog');
+
+const ISSUE_16_THEMES = [
+  {
+    id: 'google',
+    label: 'Google Material',
+    light: '#f8fafd',
+    dark: '#111318'
+  },
+  {
+    id: 'airbnb',
+    label: 'Airbnb 暖居',
+    light: '#fff8f2',
+    dark: '#211a18'
+  }
+];
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+function signaturePath(id) {
+  return path.join(__dirname, `../public/css/markdown-${id}.css`);
+}
+
+function parseHexTokens(block) {
+  return Object.fromEntries(
+    [...block.matchAll(/--([a-z0-9-]+):\s*(#[0-9a-f]{6})\s*;/gi)]
+      .map(([, name, value]) => [name, value.toLowerCase()])
+  );
+}
+
+function appearanceTokens(css) {
+  const roots = [...css.matchAll(/:root\s*\{([^}]+)\}/g)].map(match => parseHexTokens(match[1]));
+
+  assert.equal(roots.length, 2, 'signature must define one light and one dark token set');
+  return { light: roots[0], dark: roots[1] };
+}
+
+function relativeLuminance(hex) {
+  const channels = hex.slice(1).match(/.{2}/g).map(value => parseInt(value, 16) / 255);
+  const [red, green, blue] = channels.map(value => (
+    value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  ));
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground, background) {
+  const values = [relativeLuminance(foreground), relativeLuminance(background)].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
+
+test('Issue #16 entries occupy their formal relative Catalog order with trusted appearances', () => {
+  const ids = MARKDOWN_THEME_CATALOG.map(({ id }) => id);
+  const options = getMarkdownThemeOptions();
+  const formalOrder = [
+    'bytedance', 'github', 'apple', 'notion', 'claude', 'raycast',
+    'google', 'tesla', 'airbnb', 'bugatti', 'linear', 'playstation'
+  ];
+
+  assert.deepEqual(
+    ids.filter(id => formalOrder.includes(id)),
+    formalOrder.filter(id => ids.includes(id))
+  );
+
+  for (const expected of ISSUE_16_THEMES) {
+    const theme = resolveMarkdownTheme(expected.id);
+
+    assert.equal(theme.id, expected.id);
+    assert.equal(theme.label, expected.label);
+    assert.equal(theme.signatureHref, `/css/markdown-${expected.id}.css`);
+    assert.deepEqual(theme.appearances, {
+      light: { canvas: expected.light, themeColor: expected.light },
+      dark: { canvas: expected.dark, themeColor: expected.dark }
+    });
+    assert.deepEqual(options.find(({ id }) => id === expected.id), {
+      id: expected.id,
+      label: expected.label
+    });
+  }
+});
+
+test('renderer resolves both signatures, adaptive metadata, and no optional runtime for plain Markdown', async () => {
+  for (const expected of ISSUE_16_THEMES) {
+    const html = await renderMarkdown('# Signature\n\nPlain theme proof.', expected.id);
+
+    assert.match(html, new RegExp(`data-markdown-theme="${expected.id}"`));
+    assert.ok(html.indexOf('/css/markdown-theme-baseline.css') < html.indexOf(`/css/markdown-${expected.id}.css`));
+    assert.match(html, new RegExp(`<meta name="theme-color" content="${expected.light}" media="\\(prefers-color-scheme: light\\)">`));
+    assert.match(html, new RegExp(`<meta name="theme-color" content="${expected.dark}" media="\\(prefers-color-scheme: dark\\)">`));
+    assert.doesNotMatch(html, /mermaid\.min\.js|highlight\.min\.js|fonts\.googleapis\.com/);
+  }
+});
+
+test('both signatures stay local, static, system-font, adaptive, and baseline-compatible', () => {
+  const baseline = fs.readFileSync(
+    path.join(__dirname, '../public/css/markdown-theme-baseline.css'),
+    'utf8'
+  );
+
+  assert.match(baseline, /:focus-visible[^}]*outline:\s*3px solid var\(--theme-focus\)/s);
+  assert.match(baseline, /:where\(pre, table, \.mermaid[^}]*overflow:\s*auto/s);
+
+  for (const { id } of ISSUE_16_THEMES) {
+    const css = fs.readFileSync(signaturePath(id), 'utf8');
+
+    assert.match(css, /font-family:[^;]*(?:system-ui|-apple-system|BlinkMacSystemFont)/i);
+    assert.match(css, /@media \(prefers-color-scheme:\s*dark\)/);
+    assert.doesNotMatch(css, /@import|url\s*\(|https?:|@font-face|animation\s*:|@keyframes|filter:\s*blur/i);
+    assert.doesNotMatch(css, /logo|badge|search-bar|hero-image/i);
+  }
+});
+
+test('Google signature uses tonal surfaces, asymmetric corners, controlled blue, and one secondary marker', () => {
+  const css = fs.readFileSync(signaturePath('google'), 'utf8');
+
+  assert.match(css, /--theme-accent:\s*#0b57d0/i);
+  assert.match(css, /--theme-tonal-surface:\s*#[0-9a-f]{6}/i);
+  assert.match(css, /--theme-secondary:\s*#[0-9a-f]{6}/i);
+  assert.match(css, /border-radius:\s*28px 8px 28px 8px/i);
+  assert.match(css, /\.markdown-body h2::after\s*\{[^}]*background:\s*var\(--theme-secondary\)/is);
+  assert.doesNotMatch(css, /linear-gradient|radial-gradient|#34a853|#fbbc0[45]|#ea4335/i);
+});
+
+test('Airbnb signature uses warm terracotta, friendly surfaces, one metadata pill, and shallow depth', () => {
+  const css = fs.readFileSync(signaturePath('airbnb'), 'utf8');
+
+  assert.match(css, /--theme-accent:\s*#963f30/i);
+  assert.match(css, /border-radius:\s*18px/i);
+  assert.match(css, /\.markdown-body h6\s*\{[^}]*display:\s*inline-flex[^}]*border-radius:\s*999px/is);
+  assert.match(css, /--theme-surface-shadow:\s*0 4px 14px rgba\(/i);
+  assert.match(css, /box-shadow:\s*var\(--theme-surface-shadow\)/i);
+  assert.doesNotMatch(css, /#ff385c|#e00b41|rausch|search-bar|search-card/i);
+});
+
+test('both light and dark palettes meet contrast contracts for every representative role', () => {
+  const textPairs = [
+    ['theme-text', 'theme-canvas'],
+    ['theme-muted', 'theme-canvas'],
+    ['theme-link', 'theme-canvas'],
+    ['theme-quote-text', 'theme-quote-surface'],
+    ['theme-code-text', 'theme-code-surface'],
+    ['theme-table-heading', 'theme-table-heading-surface'],
+    ['theme-diagram-text', 'theme-diagram-node-surface']
+  ];
+
+  for (const { id } of ISSUE_16_THEMES) {
+    const tokensByAppearance = appearanceTokens(fs.readFileSync(signaturePath(id), 'utf8'));
+
+    for (const [appearance, tokens] of Object.entries(tokensByAppearance)) {
+      for (const [foregroundName, backgroundName] of textPairs) {
+        const ratio = contrastRatio(tokens[foregroundName], tokens[backgroundName]);
+        assert.ok(
+          ratio >= 4.5,
+          `${id} ${appearance} ${foregroundName}/${backgroundName} contrast ${ratio.toFixed(2)} is below 4.5`
+        );
+      }
+
+      const focusRatio = contrastRatio(tokens['theme-focus'], tokens['theme-canvas']);
+      assert.ok(focusRatio >= 3, `${id} ${appearance} focus contrast ${focusRatio.toFixed(2)} is below 3`);
+    }
+  }
+});
+
+test('creator, API, metadata, admin, and public flows round-trip both stable IDs', async () => {
+  const homepage = await request('/');
+
+  assert.equal(homepage.status, 200);
+
+  for (const { id, label } of ISSUE_16_THEMES) {
+    const preservedExpiry = Date.now() + 86_400_000;
+    const preservedPassword = id === 'google' ? 'Goo9!?' : 'Air9!?';
+    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+
+    const preview = await jsonRequest('/api/pages/preview', 'POST', {
+      htmlContent: `# ${label} preview`,
+      codeType: 'markdown',
+      markdownTheme: id
+    });
+    assert.equal(preview.status, 200);
+    assert.match(preview.body.document, new RegExp(`/css/markdown-${id}\\.css`));
+
+    const created = await jsonRequest('/api/pages/create', 'POST', {
+      htmlContent: `# ${label} creator`,
+      codeType: 'markdown',
+      markdownTheme: id,
+      description: `${label} preserved description`,
+      expiresAt: preservedExpiry,
+      isProtected: true,
+      password: preservedPassword
+    });
+    assert.equal(created.status, 200);
+    assert.equal(created.body.markdownTheme, id);
+
+    const metadata = await request(`/api/pages/${created.body.urlId}`);
+    assert.equal(metadata.status, 200);
+    assert.equal(metadata.body.page.markdownTheme, id);
+
+    const unlock = await jsonRequest(`/view/${created.body.urlId}/password`, 'POST', {
+      password: preservedPassword
+    });
+    assert.equal(unlock.status, 200);
+    const accessCookie = unlock.headers['set-cookie'].map(value => value.split(';')[0]).join('; ');
+    const publicView = await request(`/view/${created.body.urlId}`, {
+      headers: { Cookie: accessCookie }
+    });
+    assert.equal(publicView.status, 200);
+    assert.match(publicView.text, new RegExp(`data-markdown-theme=&quot;${id}&quot;`));
+    assert.match(publicView.text, new RegExp(`/css/markdown-${id}\\.css`));
+
+    const apiCreated = await jsonRequest('/api/v1/share', 'POST', {
+      htmlContent: `# ${label} API`,
+      codeType: 'markdown',
+      markdownTheme: id
+    }, { 'X-API-Key': 'issue-16-theme-key' });
+    assert.equal(apiCreated.status, 200);
+    assert.equal(apiCreated.body.markdownTheme, id);
+
+    await app.locals.pageRepository.setFavorite(created.body.urlId, true);
+    await app.locals.pageRepository.recordViewEvent(created.body.urlId, Date.now(), true);
+    const beforeUpdate = await app.locals.pageRepository.getById(created.body.urlId);
+    const preservedPasswordHash = beforeUpdate.password_hash;
+    const preservedEncryptedPassword = beforeUpdate.encrypted_password;
+    const preservedViewCount = beforeUpdate.view_count;
+
+    const updated = await jsonRequest(`/admin/pages/${created.body.urlId}`, 'PUT', {
+      markdownTheme: id === 'google' ? 'airbnb' : 'google'
+    });
+    assert.equal(updated.status, 200);
+    assert.equal(updated.body.page.markdownTheme, id === 'google' ? 'airbnb' : 'google');
+
+    const stored = await app.locals.pageRepository.getById(created.body.urlId);
+    assert.equal(stored.html_content, `# ${label} creator`);
+    assert.equal(stored.title, `${label} creator`);
+    assert.equal(stored.description, `${label} preserved description`);
+    assert.equal(stored.password_hash, preservedPasswordHash);
+    assert.equal(stored.encrypted_password, preservedEncryptedPassword);
+    assert.equal(stored.is_protected, 1);
+    assert.equal(stored.expires_at, preservedExpiry);
+    assert.equal(stored.is_favorite, true);
+    assert.equal(stored.view_count, preservedViewCount);
+  }
+});

--- a/test/markdown-theme-google-airbnb.test.js
+++ b/test/markdown-theme-google-airbnb.test.js
@@ -135,7 +135,8 @@ test('Issue #16 entries occupy their formal relative Catalog order with trusted 
     });
     assert.deepEqual(options.find(({ id }) => id === expected.id), {
       id: expected.id,
-      label: expected.label
+      label: expected.label,
+      signatureHref: `/css/markdown-${expected.id}.css`
     });
   }
 });
@@ -230,7 +231,7 @@ test('creator, API, metadata, admin, and public flows round-trip both stable IDs
   for (const { id, label } of ISSUE_16_THEMES) {
     const preservedExpiry = Date.now() + 86_400_000;
     const preservedPassword = id === 'google' ? 'Goo9!?' : 'Air9!?';
-    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+    assert.match(homepage.text, new RegExp(`<option\\b(?=[^>]*value="${id}")[^>]*>\\s*${label}</option>`));
 
     const preview = await jsonRequest('/api/pages/preview', 'POST', {
       htmlContent: `# ${label} preview`,

--- a/test/markdown-theme-http.test.js
+++ b/test/markdown-theme-http.test.js
@@ -38,6 +38,7 @@ function request(route, options = {}) {
       res.on('data', chunk => { text += chunk; });
       res.on('end', () => resolve({
         status: res.statusCode,
+        headers: res.headers,
         text,
         body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
       }));
@@ -55,31 +56,41 @@ function jsonRequest(route, method, value, headers = {}) {
   });
 }
 
-async function seedMarkdownPage({
+async function seedMarkdownShare({
   id,
   markdownTheme,
   title = id,
   description = 'theme boundary',
   codeType = 'markdown',
-  htmlContent = '# Theme boundary\n\n| Column | Value |\n| --- | --- |\n| Width | bounded |'
+  htmlContent = '# Theme boundary\n\n| Column | Value |\n| --- | --- |\n| Width | bounded |',
+  passwordHash = null,
+  encryptedPassword = null,
+  isProtected = false,
+  expiresAt = null,
+  isFavorite = false,
+  viewCount = 0
 }) {
   await app.locals.pageRepository.create({
     id,
     htmlContent,
     createdAt: Date.now(),
-    passwordHash: null,
-    encryptedPassword: null,
-    isProtected: false,
+    passwordHash,
+    encryptedPassword,
+    isProtected,
     codeType,
     title,
     description,
-    expiresAt: null,
+    expiresAt,
     markdownTheme
   });
+
+  const stored = await app.locals.pageRepository.getById(id);
+  stored.is_favorite = isFavorite;
+  stored.view_count = viewCount;
 }
 
 test('homepage and admin edit render the same Catalog projection', async () => {
-  await seedMarkdownPage({ id: 'catalog-admin', markdownTheme: 'github' });
+  await seedMarkdownShare({ id: 'catalog-admin', markdownTheme: 'github' });
   const [homepage, admin] = await Promise.all([
     request('/'),
     request('/admin/pages/catalog-admin')
@@ -118,8 +129,22 @@ test('preview and browser creation normalize unknown themes through ByteDance', 
   assert.equal(stored.markdown_theme, 'bytedance');
 });
 
+test('Share API normalizes an unknown Markdown theme through the same Catalog', async () => {
+  const response = await jsonRequest('/api/v1/share', 'POST', {
+    htmlContent: '# Share API fallback',
+    codeType: 'markdown',
+    markdownTheme: 'stale-browser-theme'
+  }, { 'X-API-Key': 'markdown-theme-http-key' });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.markdownTheme, 'bytedance');
+
+  const stored = await app.locals.pageRepository.getById(response.body.urlId);
+  assert.equal(stored.markdown_theme, 'bytedance');
+});
+
 test('public reads render invalid stored values through ByteDance without rewriting them', async () => {
-  await seedMarkdownPage({ id: 'legacy-invalid-theme', markdownTheme: 'legacy-invalid' });
+  await seedMarkdownShare({ id: 'legacy-invalid-theme', markdownTheme: 'legacy-invalid' });
 
   const response = await request('/view/legacy-invalid-theme');
   const stored = await app.locals.pageRepository.getById('legacy-invalid-theme');
@@ -131,11 +156,18 @@ test('public reads render invalid stored values through ByteDance without rewrit
 });
 
 test('theme-only admin updates normalize the ID and preserve unrelated Share fields', async () => {
-  await seedMarkdownPage({
+  const preservedExpiry = Date.now() + 86_400_000;
+  await seedMarkdownShare({
     id: 'theme-only-update',
     markdownTheme: 'github',
     title: 'Preserved title',
-    description: 'Preserved description'
+    description: 'Preserved description',
+    passwordHash: 'preserved-password-hash',
+    encryptedPassword: 'preserved-encrypted-password',
+    isProtected: true,
+    expiresAt: preservedExpiry,
+    isFavorite: true,
+    viewCount: 17
   });
 
   const response = await jsonRequest('/admin/pages/theme-only-update', 'PUT', {
@@ -149,12 +181,16 @@ test('theme-only admin updates normalize the ID and preserve unrelated Share fie
   assert.equal(stored.title, 'Preserved title');
   assert.equal(stored.description, 'Preserved description');
   assert.equal(stored.html_content.startsWith('# Theme boundary'), true);
-  assert.equal(stored.is_protected, 0);
-  assert.equal(stored.expires_at, null);
+  assert.equal(stored.password_hash, 'preserved-password-hash');
+  assert.equal(stored.encrypted_password, 'preserved-encrypted-password');
+  assert.equal(stored.is_protected, 1);
+  assert.equal(stored.expires_at, preservedExpiry);
+  assert.equal(stored.is_favorite, true);
+  assert.equal(stored.view_count, 17);
 });
 
 test('admin theme writes normalize an empty value to ByteDance', async () => {
-  await seedMarkdownPage({
+  await seedMarkdownShare({
     id: 'empty-theme-update',
     markdownTheme: 'github'
   });
@@ -170,7 +206,7 @@ test('admin theme writes normalize an empty value to ByteDance', async () => {
 });
 
 test('admin theme input does not add Markdown state to a non-Markdown Share', async () => {
-  await seedMarkdownPage({
+  await seedMarkdownShare({
     id: 'html-theme-boundary',
     markdownTheme: null,
     codeType: 'html',
@@ -186,4 +222,47 @@ test('admin theme input does not add Markdown state to a non-Markdown Share', as
   assert.equal(stored.code_type, 'html');
   assert.equal(stored.markdown_theme, null);
   assert.equal(stored.html_content, '<h1>HTML boundary</h1>');
+});
+
+test('cloning normalizes every legacy Markdown theme and keeps non-Markdown theme state null', async () => {
+  for (const [suffix, markdownTheme] of [
+    ['null', null],
+    ['random', 'random'],
+    ['invalid', 'legacy-invalid']
+  ]) {
+    const sourceId = `clone-${suffix}-theme`;
+    await seedMarkdownShare({ id: sourceId, markdownTheme });
+
+    const response = await request(`/admin/pages/${sourceId}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: '_csrf='
+    });
+    assert.equal(response.status, 302);
+
+    const cloneId = response.headers.location.split('/').pop();
+    const clone = await app.locals.pageRepository.getById(cloneId);
+
+    assert.equal(clone.code_type, 'markdown');
+    assert.equal(clone.markdown_theme, 'bytedance');
+  }
+
+  await seedMarkdownShare({
+    id: 'clone-html-theme',
+    markdownTheme: 'legacy-invalid',
+    codeType: 'html',
+    htmlContent: '<p>HTML clone</p>'
+  });
+  const response = await request('/admin/pages/clone-html-theme/clone', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: '_csrf='
+  });
+  assert.equal(response.status, 302);
+
+  const cloneId = response.headers.location.split('/').pop();
+  const clone = await app.locals.pageRepository.getById(cloneId);
+
+  assert.equal(clone.code_type, 'html');
+  assert.equal(clone.markdown_theme, null);
 });

--- a/test/markdown-theme-http.test.js
+++ b/test/markdown-theme-http.test.js
@@ -100,10 +100,16 @@ test('homepage and admin edit render the same Catalog projection', async () => {
   assert.equal(admin.status, 200);
 
   for (const { id, label } of getMarkdownThemeOptions()) {
-    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
-    assert.match(admin.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+    const optionPattern = new RegExp(
+      `<option\\b(?=[^>]*value="${id}")[^>]*>${label}</option>`
+    );
+    assert.match(homepage.text, optionPattern);
+    assert.match(admin.text, optionPattern);
   }
-  assert.match(admin.text, /<option value="github" selected>GitHub 经典<\/option>/);
+  assert.match(
+    admin.text,
+    /<option\b(?=[^>]*value="github")(?=[^>]*selected)[^>]*>GitHub 经典<\/option>/
+  );
 });
 
 test('preview and browser creation normalize unknown themes through ByteDance', async () => {

--- a/test/markdown-theme-http.test.js
+++ b/test/markdown-theme-http.test.js
@@ -1,0 +1,189 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'markdown-theme-http-key';
+process.env.SESSION_SECRET = 'markdown-theme-http-secret';
+
+const app = require('../app');
+const { getMarkdownThemeOptions } = require('../utils/markdownThemeCatalog');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+async function seedMarkdownPage({
+  id,
+  markdownTheme,
+  title = id,
+  description = 'theme boundary',
+  codeType = 'markdown',
+  htmlContent = '# Theme boundary\n\n| Column | Value |\n| --- | --- |\n| Width | bounded |'
+}) {
+  await app.locals.pageRepository.create({
+    id,
+    htmlContent,
+    createdAt: Date.now(),
+    passwordHash: null,
+    encryptedPassword: null,
+    isProtected: false,
+    codeType,
+    title,
+    description,
+    expiresAt: null,
+    markdownTheme
+  });
+}
+
+test('homepage and admin edit render the same Catalog projection', async () => {
+  await seedMarkdownPage({ id: 'catalog-admin', markdownTheme: 'github' });
+  const [homepage, admin] = await Promise.all([
+    request('/'),
+    request('/admin/pages/catalog-admin')
+  ]);
+
+  assert.equal(homepage.status, 200);
+  assert.equal(admin.status, 200);
+
+  for (const { id, label } of getMarkdownThemeOptions()) {
+    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+    assert.match(admin.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+  }
+  assert.match(admin.text, /<option value="github" selected>GitHub 经典<\/option>/);
+});
+
+test('preview and browser creation normalize unknown themes through ByteDance', async () => {
+  const preview = await jsonRequest('/api/pages/preview', 'POST', {
+    htmlContent: '# Preview fallback',
+    codeType: 'markdown',
+    markdownTheme: '../unsafe.css'
+  });
+  const created = await jsonRequest('/api/pages/create', 'POST', {
+    htmlContent: '# Create fallback',
+    codeType: 'markdown',
+    markdownTheme: 'removed-theme'
+  });
+
+  assert.equal(preview.status, 200);
+  assert.match(preview.body.document, /markdown-theme-baseline\.css/);
+  assert.match(preview.body.document, /markdown-bytedance\.css/);
+  assert.doesNotMatch(preview.body.document, /unsafe\.css/);
+  assert.equal(created.status, 200);
+  assert.equal(created.body.markdownTheme, 'bytedance');
+
+  const stored = await app.locals.pageRepository.getById(created.body.urlId);
+  assert.equal(stored.markdown_theme, 'bytedance');
+});
+
+test('public reads render invalid stored values through ByteDance without rewriting them', async () => {
+  await seedMarkdownPage({ id: 'legacy-invalid-theme', markdownTheme: 'legacy-invalid' });
+
+  const response = await request('/view/legacy-invalid-theme');
+  const stored = await app.locals.pageRepository.getById('legacy-invalid-theme');
+
+  assert.equal(response.status, 200);
+  assert.match(response.text, /markdown-theme-baseline\.css/);
+  assert.match(response.text, /markdown-bytedance\.css/);
+  assert.equal(stored.markdown_theme, 'legacy-invalid');
+});
+
+test('theme-only admin updates normalize the ID and preserve unrelated Share fields', async () => {
+  await seedMarkdownPage({
+    id: 'theme-only-update',
+    markdownTheme: 'github',
+    title: 'Preserved title',
+    description: 'Preserved description'
+  });
+
+  const response = await jsonRequest('/admin/pages/theme-only-update', 'PUT', {
+    markdownTheme: '../../unsafe.css'
+  });
+  const stored = await app.locals.pageRepository.getById('theme-only-update');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.page.markdownTheme, 'bytedance');
+  assert.equal(stored.markdown_theme, 'bytedance');
+  assert.equal(stored.title, 'Preserved title');
+  assert.equal(stored.description, 'Preserved description');
+  assert.equal(stored.html_content.startsWith('# Theme boundary'), true);
+  assert.equal(stored.is_protected, 0);
+  assert.equal(stored.expires_at, null);
+});
+
+test('admin theme writes normalize an empty value to ByteDance', async () => {
+  await seedMarkdownPage({
+    id: 'empty-theme-update',
+    markdownTheme: 'github'
+  });
+
+  const response = await jsonRequest('/admin/pages/empty-theme-update', 'PUT', {
+    markdownTheme: ''
+  });
+  const stored = await app.locals.pageRepository.getById('empty-theme-update');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.page.markdownTheme, 'bytedance');
+  assert.equal(stored.markdown_theme, 'bytedance');
+});
+
+test('admin theme input does not add Markdown state to a non-Markdown Share', async () => {
+  await seedMarkdownPage({
+    id: 'html-theme-boundary',
+    markdownTheme: null,
+    codeType: 'html',
+    htmlContent: '<h1>HTML boundary</h1>'
+  });
+
+  const response = await jsonRequest('/admin/pages/html-theme-boundary', 'PUT', {
+    markdownTheme: 'github'
+  });
+  const stored = await app.locals.pageRepository.getById('html-theme-boundary');
+
+  assert.equal(response.status, 200);
+  assert.equal(stored.code_type, 'html');
+  assert.equal(stored.markdown_theme, null);
+  assert.equal(stored.html_content, '<h1>HTML boundary</h1>');
+});

--- a/test/markdown-theme-issue13.test.js
+++ b/test/markdown-theme-issue13.test.js
@@ -1,0 +1,382 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'markdown-theme-issue13-key';
+process.env.SESSION_SECRET = 'markdown-theme-issue13-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const { resolveMarkdownTheme } = require('../utils/markdownThemeCatalog');
+
+const THEME_IDS = ['notion', 'claude'];
+const REQUIRED_TOKENS = [
+  'canvas',
+  'text',
+  'muted',
+  'accent',
+  'link',
+  'border',
+  'quote-surface',
+  'table-surface',
+  'diagram-surface',
+  'diagram-text',
+  'diagram-node-surface',
+  'diagram-node-border',
+  'diagram-line',
+  'diagram-label-surface',
+  'code-text',
+  'code-surface',
+  'focus',
+  'heading-on-accent',
+  'font-family'
+];
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, value, headers = {}, method = 'POST') {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+function readSignature(id) {
+  return fs.readFileSync(
+    path.join(__dirname, `../public/css/markdown-${id}.css`),
+    'utf8'
+  );
+}
+
+function declarationBlock(css, appearance) {
+  const source = appearance === 'light'
+    ? css
+    : css.match(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{([\s\S]+)\}\s*$/i)?.[1] || '';
+  return source.match(/:root\s*\{([^}]*)\}/i)?.[1] || '';
+}
+
+function tokensFor(css, appearance) {
+  const tokens = new Map();
+  for (const match of declarationBlock(css, appearance).matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+    tokens.set(match[1].toLowerCase(), match[2].trim());
+  }
+  return tokens;
+}
+
+function rgb(hex) {
+  const match = /^#([0-9a-f]{6})$/i.exec(hex);
+  assert.ok(match, `expected a six-digit color, received ${hex}`);
+  return [0, 2, 4].map(offset => Number.parseInt(match[1].slice(offset, offset + 2), 16));
+}
+
+function luminance(hex) {
+  const channels = rgb(hex).map(value => {
+    const normalized = value / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+  return (0.2126 * channels[0]) + (0.7152 * channels[1]) + (0.0722 * channels[2]);
+}
+
+function contrast(first, second) {
+  const [lighter, darker] = [luminance(first), luminance(second)].sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function assertContrast(tokens, foreground, background, minimum) {
+  const ratio = contrast(tokens.get(foreground), tokens.get(background));
+  assert.ok(
+    ratio >= minimum,
+    `${foreground} on ${background} is ${ratio.toFixed(2)}:1; expected at least ${minimum}:1`
+  );
+}
+
+test('Issue #13 signatures expose complete light and dark shared-token contracts', () => {
+  for (const id of THEME_IDS) {
+    const css = readSignature(id);
+
+    for (const appearance of ['light', 'dark']) {
+      const tokens = tokensFor(css, appearance);
+      for (const token of REQUIRED_TOKENS) {
+        assert.ok(tokens.has(`theme-${token}`), `${id} ${appearance} is missing --theme-${token}`);
+      }
+
+      for (const [foreground, background, minimum] of [
+        ['theme-text', 'theme-canvas', 4.5],
+        ['theme-muted', 'theme-canvas', 4.5],
+        ['theme-link', 'theme-canvas', 4.5],
+        ['theme-muted', 'theme-quote-surface', 4.5],
+        ['theme-text', 'theme-table-surface', 4.5],
+        ['theme-code-text', 'theme-code-surface', 4.5],
+        ['theme-diagram-text', 'theme-diagram-surface', 4.5],
+        ['theme-focus', 'theme-canvas', 3]
+      ]) {
+        assertContrast(tokens, foreground, background, minimum);
+      }
+    }
+  }
+});
+
+test('Notion and Claude Catalog canvas metadata matches both signature appearances', async () => {
+  for (const id of THEME_IDS) {
+    const css = readSignature(id);
+    const theme = resolveMarkdownTheme(id);
+    const lightCanvas = tokensFor(css, 'light').get('theme-canvas');
+    const darkCanvas = tokensFor(css, 'dark').get('theme-canvas');
+    const html = await renderMarkdown(`# ${id} appearance`, id);
+
+    assert.equal(theme.appearances.light.canvas, lightCanvas);
+    assert.equal(theme.appearances.light.themeColor, lightCanvas);
+    assert.equal(theme.appearances.dark.canvas, darkCanvas);
+    assert.equal(theme.appearances.dark.themeColor, darkCanvas);
+    assert.match(html, new RegExp(`--theme-canvas: ${lightCanvas}`));
+    assert.match(html, new RegExp(`--theme-canvas: ${darkCanvas}`));
+  }
+});
+
+test('Issue #13 signatures use only local styling and system font families', () => {
+  for (const id of THEME_IDS) {
+    const css = readSignature(id);
+
+    assert.doesNotMatch(css, /@import|@font-face|url\s*\(|https?:\/\//i);
+    assert.doesNotMatch(css, /JetBrains|Inter|Styrene|Copernicus|Tiempos/i);
+    assert.doesNotMatch(css, /@keyframes|\banimation\s*:|filter\s*:\s*blur/i);
+
+    for (const appearance of ['light', 'dark']) {
+      assert.match(
+        tokensFor(css, appearance).get('theme-font-family') || '',
+        /ui-sans-serif|system-ui|-apple-system/i
+      );
+    }
+  }
+});
+
+test('Notion keeps note surfaces, body-color links, red inline code, and explicit task states', async () => {
+  const css = readSignature('notion');
+  const baseline = fs.readFileSync(
+    path.join(__dirname, '../public/css/markdown-theme-baseline.css'),
+    'utf8'
+  );
+  const renderedTasks = await renderMarkdown('- [ ] Open task\n- [x] Completed task', 'notion');
+
+  for (const appearance of ['light', 'dark']) {
+    const tokens = tokensFor(css, appearance);
+    assert.equal(tokens.get('theme-link'), tokens.get('theme-text'));
+    assert.ok(tokens.has('notion-inline-code'));
+    assert.ok(tokens.has('notion-inline-code-surface'));
+
+    const [red, green, blue] = rgb(tokens.get('notion-inline-code'));
+    assert.ok(red > green && red > blue, `Notion ${appearance} inline code must remain red`);
+    assertContrast(tokens, 'notion-inline-code', 'notion-inline-code-surface', 4.5);
+  }
+
+  assert.match(renderedTasks, /<li><input disabled="" type="checkbox"> Open task<\/li>/);
+  assert.match(renderedTasks, /<li><input checked="" disabled="" type="checkbox"> Completed task<\/li>/);
+  assert.match(baseline, /li:has\(> input\[type=["']checkbox["']\]\)/);
+  assert.match(css, /li:has\(> input\[type=["']checkbox["']\]:checked\)/);
+  assert.match(css, /input\[type=["']checkbox["']\]:checked/);
+  assert.match(css, /input\[type=["']checkbox["']\]:not\(:checked\)/);
+  assert.match(css, /border-radius:\s*(?:[0-5](?:\.\d+)?(?:px|rem|em))/i);
+});
+
+test('Claude keeps warm paper, system-serif headings, and terracotta accents', () => {
+  const css = readSignature('claude');
+
+  for (const appearance of ['light', 'dark']) {
+    const tokens = tokensFor(css, appearance);
+    const headingFont = tokens.get('claude-heading-font') || '';
+    const [red, green, blue] = rgb(tokens.get('theme-accent'));
+
+    assert.match(headingFont, /ui-serif|Georgia|Cambria|Times/i);
+    assert.ok(red > green && green > blue, `Claude ${appearance} accent must remain terracotta`);
+    assert.equal(tokens.get('theme-link'), tokens.get('theme-accent'));
+  }
+
+  assert.match(css, /font-family:\s*var\(--claude-heading-font\)/i);
+  assert.match(css, /blockquote[^}]*border-left:[^;}]*var\(--theme-accent\)/is);
+});
+
+test('Notion and Claude render through the baseline and retain conditional optional assets', async () => {
+  const fence = '`'.repeat(3);
+
+  for (const id of THEME_IDS) {
+    const plain = await renderMarkdown('# Local theme\n\nA [link](https://example.com).', id);
+    const codeOnly = await renderMarkdown(
+      `${fence}js\nconst answer = 42;\n${fence}`,
+      id
+    );
+    const mermaidOnly = await renderMarkdown(
+      `${fence}mermaid\ngraph TD\nA-->B\n${fence}`,
+      id
+    );
+
+    assert.ok(
+      plain.indexOf('/css/markdown-theme-baseline.css') < plain.indexOf(`/css/markdown-${id}.css`)
+    );
+    assert.match(plain, new RegExp(`data-markdown-theme="${id}"`));
+    assert.doesNotMatch(plain, /fonts\.googleapis\.com|highlight\.min\.js|mermaid\.min\.js/);
+
+    assert.match(codeOnly, /highlight\.min\.js/);
+    assert.doesNotMatch(codeOnly, /mermaid\.min\.js/);
+    assert.doesNotMatch(mermaidOnly, /highlight\.min\.js/);
+    assert.match(mermaidOnly, /mermaid\.min\.js/);
+    assert.equal((codeOnly.match(new RegExp(`markdown-${id}\\.css`, 'g')) || []).length, 1);
+    assert.equal((mermaidOnly.match(new RegExp(`markdown-${id}\\.css`, 'g')) || []).length, 1);
+  }
+});
+
+test('Notion and Claude round-trip through preview, browser create, metadata, admin, and public view', async () => {
+  const homepage = await request('/');
+  assert.equal(homepage.status, 200);
+
+  for (const id of THEME_IDS) {
+    assert.match(homepage.text, new RegExp(`<option value="${id}"`));
+
+    const preview = await jsonRequest('/api/pages/preview', {
+      htmlContent: `# ${id} preview`,
+      codeType: 'markdown',
+      markdownTheme: id
+    });
+    assert.equal(preview.status, 200);
+    assert.match(preview.body.document, new RegExp(`markdown-${id}\\.css`));
+
+    const created = await jsonRequest('/api/pages/create', {
+      htmlContent: `# ${id} browser create`,
+      codeType: 'markdown',
+      markdownTheme: id,
+      title: `${id} title`,
+      description: `${id} description`
+    });
+    assert.equal(created.status, 200);
+    assert.equal(created.body.markdownTheme, id);
+
+    const [stored, metadata, admin, publicView] = await Promise.all([
+      app.locals.pageRepository.getById(created.body.urlId),
+      request(`/api/pages/${created.body.urlId}`),
+      request(`/admin/pages/${created.body.urlId}`),
+      request(`/view/${created.body.urlId}`)
+    ]);
+
+    assert.equal(stored.markdown_theme, id);
+    assert.equal(metadata.status, 200);
+    assert.equal(metadata.body.page.markdownTheme, id);
+    assert.equal(admin.status, 200);
+    assert.match(admin.text, new RegExp(`<option value="${id}" selected>`));
+    assert.equal(publicView.status, 200);
+    assert.match(publicView.text, new RegExp(`markdown-${id}\\.css`));
+  }
+});
+
+test('Notion and Claude round-trip through the Share API without changing response shape', async () => {
+  const expectedResponseKeys = [
+    'codeType',
+    'description',
+    'expiresAt',
+    'isProtected',
+    'markdownTheme',
+    'password',
+    'success',
+    'title',
+    'url',
+    'urlId'
+  ];
+
+  for (const id of THEME_IDS) {
+    const response = await jsonRequest('/api/v1/share', {
+      htmlContent: `# ${id} Share API`,
+      codeType: 'markdown',
+      markdownTheme: id
+    }, { 'X-API-Key': 'markdown-theme-issue13-key' });
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.success, true);
+    assert.equal(response.body.markdownTheme, id);
+    assert.equal(typeof response.body.urlId, 'string');
+    assert.deepEqual(Object.keys(response.body).sort(), expectedResponseKeys);
+
+    const stored = await app.locals.pageRepository.getById(response.body.urlId);
+    assert.equal(stored.markdown_theme, id);
+  }
+});
+
+test('a Notion-to-Claude admin theme update preserves unrelated Share state', async () => {
+  const id = 'issue13-theme-only-isolation';
+  const expiresAt = Date.now() + 86_400_000;
+  await app.locals.pageRepository.create({
+    id,
+    htmlContent: '# Preserved content',
+    createdAt: Date.now(),
+    passwordHash: 'preserved-password-hash',
+    encryptedPassword: 'preserved-encrypted-password',
+    isProtected: true,
+    codeType: 'markdown',
+    title: 'Preserved title',
+    description: 'Preserved description',
+    expiresAt,
+    markdownTheme: 'notion'
+  });
+  const seeded = await app.locals.pageRepository.getById(id);
+  seeded.is_favorite = true;
+  seeded.view_count = 23;
+
+  const response = await jsonRequest(
+    `/admin/pages/${id}`,
+    { markdownTheme: 'claude' },
+    {},
+    'PUT'
+  );
+  const stored = await app.locals.pageRepository.getById(id);
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.page.markdownTheme, 'claude');
+  assert.equal(stored.markdown_theme, 'claude');
+  assert.equal(stored.html_content, '# Preserved content');
+  assert.equal(stored.title, 'Preserved title');
+  assert.equal(stored.description, 'Preserved description');
+  assert.equal(stored.password_hash, 'preserved-password-hash');
+  assert.equal(stored.encrypted_password, 'preserved-encrypted-password');
+  assert.equal(stored.is_protected, 1);
+  assert.equal(stored.expires_at, expiresAt);
+  assert.equal(stored.is_favorite, true);
+  assert.equal(stored.view_count, 23);
+});

--- a/test/markdown-theme-issue13.test.js
+++ b/test/markdown-theme-issue13.test.js
@@ -270,7 +270,7 @@ test('Notion and Claude round-trip through preview, browser create, metadata, ad
   assert.equal(homepage.status, 200);
 
   for (const id of THEME_IDS) {
-    assert.match(homepage.text, new RegExp(`<option value="${id}"`));
+    assert.match(homepage.text, new RegExp(`<option\\b(?=[^>]*value="${id}")[^>]*>`));
 
     const preview = await jsonRequest('/api/pages/preview', {
       htmlContent: `# ${id} preview`,
@@ -301,7 +301,7 @@ test('Notion and Claude round-trip through preview, browser create, metadata, ad
     assert.equal(metadata.status, 200);
     assert.equal(metadata.body.page.markdownTheme, id);
     assert.equal(admin.status, 200);
-    assert.match(admin.text, new RegExp(`<option value="${id}" selected>`));
+    assert.match(admin.text, new RegExp(`<option\\b(?=[^>]*value="${id}")(?=[^>]*selected)[^>]*>`));
     assert.equal(publicView.status, 200);
     assert.match(publicView.text, new RegExp(`markdown-${id}\\.css`));
   }

--- a/test/markdown-theme-playstation.test.js
+++ b/test/markdown-theme-playstation.test.js
@@ -96,7 +96,11 @@ test('PlayStation is the final entry in the formal Catalog order with trusted lo
   const options = getMarkdownThemeOptions();
 
   assert.equal(resolveMarkdownThemeId('playstation'), 'playstation');
-  assert.deepEqual(options.at(-1), { id: 'playstation', label: 'PlayStation 蓝境' });
+  assert.deepEqual(options.at(-1), {
+    id: 'playstation',
+    label: 'PlayStation 蓝境',
+    signatureHref: '/css/markdown-playstation.css'
+  });
   assert.equal(MARKDOWN_THEME_CATALOG.at(-1), theme);
   assert.equal(theme.signatureHref, '/css/markdown-playstation.css');
   assert.deepEqual(Object.keys(theme.appearances), ['light', 'dark']);
@@ -157,7 +161,10 @@ test('PlayStation round-trips through preview, browser/API creation, metadata, a
 
   const admin = await request(`/admin/pages/${apiCreated.body.urlId}`);
   assert.equal(admin.status, 200);
-  assert.match(admin.text, /<option value="playstation" selected>PlayStation 蓝境<\/option>/);
+  assert.match(
+    admin.text,
+    /<option\b(?=[^>]*value="playstation")(?=[^>]*selected)[^>]*>\s*PlayStation 蓝境<\/option>/
+  );
 
   const update = await jsonRequest(`/admin/pages/${apiCreated.body.urlId}`, 'PUT', {
     markdownTheme: 'playstation'

--- a/test/markdown-theme-playstation.test.js
+++ b/test/markdown-theme-playstation.test.js
@@ -1,0 +1,230 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'playstation-theme-key';
+process.env.SESSION_SECRET = 'playstation-theme-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const {
+  MARKDOWN_THEME_CATALOG,
+  getMarkdownThemeOptions,
+  resolveMarkdownTheme,
+  resolveMarkdownThemeId
+} = require('../utils/markdownThemeCatalog');
+
+const PLAYSTATION_CSS_PATH = path.join(__dirname, '../public/css/markdown-playstation.css');
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+function hexToRgb(hex) {
+  const value = Number.parseInt(hex.slice(1), 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+function relativeLuminance(hex) {
+  const channels = hexToRgb(hex).map((channel) => {
+    const value = channel / 255;
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(foreground, background) {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseTokens(source) {
+  return Object.fromEntries(
+    Array.from(source.matchAll(/--theme-([a-z0-9-]+):\s*(#[0-9a-f]{6})\s*;/gi), match => [match[1], match[2]])
+  );
+}
+
+test('PlayStation is the final entry in the formal Catalog order with trusted local metadata', () => {
+  const theme = resolveMarkdownTheme('playstation');
+  const options = getMarkdownThemeOptions();
+
+  assert.equal(resolveMarkdownThemeId('playstation'), 'playstation');
+  assert.deepEqual(options.at(-1), { id: 'playstation', label: 'PlayStation 蓝境' });
+  assert.equal(MARKDOWN_THEME_CATALOG.at(-1), theme);
+  assert.equal(theme.signatureHref, '/css/markdown-playstation.css');
+  assert.deepEqual(Object.keys(theme.appearances), ['light', 'dark']);
+  assert.notEqual(theme.appearances.light.canvas, theme.appearances.dark.canvas);
+  assert.equal(theme.appearances.light.canvas, '#f1f7ff');
+  assert.equal(theme.appearances.dark.canvas, '#071629');
+});
+
+test('PlayStation renderer uses the shared baseline, one trusted signature, and no optional runtime for plain Markdown', async () => {
+  const html = await renderMarkdown('# PlayStation boundary\n\n[Focusable link](#details)', 'playstation');
+  const baselinePosition = html.indexOf('/css/markdown-theme-baseline.css');
+  const signaturePosition = html.indexOf('/css/markdown-playstation.css');
+
+  assert.ok(baselinePosition >= 0);
+  assert.ok(signaturePosition > baselinePosition);
+  assert.match(html, /<html[^>]+data-markdown-theme="playstation"/);
+  assert.match(html, /<meta name="theme-color" content="#f1f7ff" media="\(prefers-color-scheme: light\)">/);
+  assert.match(html, /<meta name="theme-color" content="#071629" media="\(prefers-color-scheme: dark\)">/);
+  assert.doesNotMatch(html, /mermaid\.min\.js|highlight\.min\.js|fonts\.googleapis\.com/);
+});
+
+test('PlayStation round-trips through preview, browser/API creation, metadata, admin editing, and public rendering', async () => {
+  const preview = await jsonRequest('/api/pages/preview', 'POST', {
+    htmlContent: '# Preview PlayStation',
+    codeType: 'markdown',
+    markdownTheme: 'playstation'
+  });
+  assert.equal(preview.status, 200);
+  assert.match(preview.body.document, /data-markdown-theme=&quot;playstation&quot;/);
+  assert.match(preview.body.document, /markdown-playstation\.css/);
+
+  const browserCreated = await jsonRequest('/api/pages/create', 'POST', {
+    htmlContent: '# Browser PlayStation',
+    codeType: 'markdown',
+    markdownTheme: 'playstation',
+    title: 'PlayStation browser Share'
+  });
+  assert.equal(browserCreated.status, 200);
+  assert.equal(browserCreated.body.markdownTheme, 'playstation');
+
+  const metadata = await request(`/api/pages/${browserCreated.body.urlId}`);
+  assert.equal(metadata.status, 200);
+  assert.equal(metadata.body.page.markdownTheme, 'playstation');
+
+  const apiCreated = await jsonRequest('/api/v1/share', 'POST', {
+    htmlContent: '# API PlayStation',
+    codeType: 'markdown',
+    markdownTheme: 'playstation'
+  }, { 'X-API-Key': 'playstation-theme-key' });
+  assert.equal(apiCreated.status, 200);
+  assert.equal(apiCreated.body.markdownTheme, 'playstation');
+
+  const stored = await app.locals.pageRepository.getById(apiCreated.body.urlId);
+  stored.is_favorite = true;
+  stored.view_count = 23;
+  const originalContent = stored.html_content;
+  const originalTitle = stored.title;
+
+  const admin = await request(`/admin/pages/${apiCreated.body.urlId}`);
+  assert.equal(admin.status, 200);
+  assert.match(admin.text, /<option value="playstation" selected>PlayStation 蓝境<\/option>/);
+
+  const update = await jsonRequest(`/admin/pages/${apiCreated.body.urlId}`, 'PUT', {
+    markdownTheme: 'playstation'
+  });
+  assert.equal(update.status, 200);
+  assert.equal(update.body.page.markdownTheme, 'playstation');
+
+  const updated = await app.locals.pageRepository.getById(apiCreated.body.urlId);
+  assert.equal(updated.markdown_theme, 'playstation');
+  assert.equal(updated.html_content, originalContent);
+  assert.equal(updated.title, originalTitle);
+  assert.equal(updated.is_favorite, true);
+  assert.equal(updated.view_count, 23);
+
+  const publicView = await request(`/view/${apiCreated.body.urlId}`);
+  assert.equal(publicView.status, 200);
+  assert.match(publicView.text, /data-markdown-theme=&quot;playstation&quot;/);
+  assert.match(publicView.text, /markdown-playstation\.css/);
+});
+
+test('PlayStation signature is local, static, geometric blue depth rather than Bugatti metallic restraint', () => {
+  const css = fs.readFileSync(PLAYSTATION_CSS_PATH, 'utf8');
+
+  assert.match(css, /\.markdown-body h1\s*\{[^}]*background:\s*linear-gradient\([^;]+\)[^}]*color:\s*var\(--theme-heading-on-accent\)/is);
+  assert.equal((css.match(/clip-path:\s*polygon\(/gi) || []).length, 1);
+  assert.match(css, /\.markdown-body h1::after\s*\{/);
+  assert.doesNotMatch(css, /@import|@font-face|url\(|animation|transition|@keyframes|filter\s*:|text-shadow|box-shadow/i);
+  assert.doesNotMatch(css, /logo|artwork|game|particle|neon|bloom|metallic|carbon|ice|vehicle|badge|texture|shine/i);
+});
+
+test('PlayStation light and dark roles meet contrast requirements including the bright dark heading gradient', () => {
+  const css = fs.readFileSync(PLAYSTATION_CSS_PATH, 'utf8');
+  const darkMatch = css.match(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{\s*:root\s*\{([^}]+)\}/i);
+
+  assert.ok(darkMatch, 'dark appearance tokens must be present');
+
+  const light = parseTokens(css.slice(0, darkMatch.index));
+  const dark = parseTokens(darkMatch[1]);
+  const textPairs = [
+    ['text', 'canvas'],
+    ['muted', 'canvas'],
+    ['link', 'canvas'],
+    ['quote-text', 'quote-surface'],
+    ['code-text', 'code-surface'],
+    ['table-heading', 'table-heading-surface'],
+    ['diagram-text', 'diagram-node-surface']
+  ];
+
+  for (const [appearance, tokens] of [['light', light], ['dark', dark]]) {
+    for (const [foreground, background] of textPairs) {
+      assert.ok(
+        contrastRatio(tokens[foreground], tokens[background]) >= 4.5,
+        `${appearance} ${foreground} must meet 4.5:1 against ${background}`
+      );
+    }
+    assert.ok(
+      contrastRatio(tokens.focus, tokens.canvas) >= 3,
+      `${appearance} focus must meet 3:1 against canvas`
+    );
+    for (const endpoint of ['heading-gradient-start', 'heading-gradient-end']) {
+      assert.ok(
+        contrastRatio(tokens['heading-on-accent'], tokens[endpoint]) >= 4.5,
+        `${appearance} heading foreground must meet 4.5:1 against ${endpoint}`
+      );
+    }
+  }
+
+  assert.ok(relativeLuminance(dark['heading-gradient-start']) > relativeLuminance(light['heading-gradient-start']));
+  assert.ok(relativeLuminance(dark['heading-on-accent']) < relativeLuminance(light['heading-on-accent']));
+});

--- a/test/markdown-theme-signatures-12.test.js
+++ b/test/markdown-theme-signatures-12.test.js
@@ -1,0 +1,214 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'markdown-theme-signatures-12-key';
+process.env.SESSION_SECRET = 'markdown-theme-signatures-12-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const { resolveMarkdownTheme } = require('../utils/markdownThemeCatalog');
+
+const PRESETS = Object.freeze([
+  {
+    id: 'github',
+    lightCanvas: '#ffffff',
+    darkCanvas: '#0d1117',
+    source: fs.readFileSync(path.join(__dirname, '../public/css/markdown-github.css'), 'utf8')
+  },
+  {
+    id: 'apple',
+    lightCanvas: '#ffffff',
+    darkCanvas: '#000000',
+    source: fs.readFileSync(path.join(__dirname, '../public/css/markdown-apple.css'), 'utf8')
+  }
+]);
+
+const SHARED_THEME_TOKENS = Object.freeze([
+  'canvas',
+  'text',
+  'muted',
+  'accent',
+  'link',
+  'border',
+  'quote-surface',
+  'table-surface',
+  'diagram-surface',
+  'code-text',
+  'code-surface',
+  'focus',
+  'heading-on-accent',
+  'font-family',
+  'diagram-text',
+  'diagram-node-surface',
+  'diagram-node-border',
+  'diagram-line',
+  'diagram-label-surface',
+  'reading-width'
+]);
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+test('Issue #12 signatures provide paired token sets without taking back baseline containment', () => {
+  for (const preset of PRESETS) {
+    assert.match(preset.source, /@media \(prefers-color-scheme:\s*dark\)/);
+
+    for (const token of SHARED_THEME_TOKENS) {
+      assert.match(preset.source, new RegExp(`--theme-${token}:`), `${preset.id} supplies ${token}`);
+    }
+
+    assert.doesNotMatch(preset.source, /@import|https?:\/\/|url\s*\(|SF Pro|@keyframes|animation\s*:|filter\s*:\s*blur/i);
+    assert.doesNotMatch(preset.source, /\b(?:max-width|overflow|word-wrap|word-break)\s*:/i);
+    assert.doesNotMatch(preset.source, /text-decoration\s*:\s*none/i, `${preset.id} keeps the baseline link cue`);
+  }
+});
+
+test('GitHub retains compact README rules without gradients or decorative depth', () => {
+  const github = PRESETS.find(({ id }) => id === 'github').source;
+
+  assert.match(github, /--theme-reading-width:\s*900px/);
+  assert.match(github, /font-size:\s*16px/);
+  assert.match(github, /line-height:\s*1\.6/);
+  assert.match(github, /border-bottom:\s*1px solid var\(--theme-border\)/);
+  assert.match(github, /color:\s*var\(--theme-link\)/);
+  assert.match(github, /border-radius:\s*(?:3|6)px/);
+  assert.doesNotMatch(github, /gradient|box-shadow|text-shadow/i);
+});
+
+test('Apple retains a narrow relaxed rhythm with plain headings and soft surfaces', () => {
+  const apple = PRESETS.find(({ id }) => id === 'apple').source;
+
+  assert.match(apple, /--theme-reading-width:\s*800px/);
+  assert.match(apple, /font-size:\s*17px/);
+  assert.match(apple, /line-height:\s*1\.7/);
+  assert.match(apple, /font-weight:\s*600/);
+  assert.match(apple, /border-radius:\s*16px/);
+  assert.match(apple, /border-radius:\s*12px/);
+  assert.doesNotMatch(apple, /gradient|text-transform|text-shadow/i);
+});
+
+test('Catalog and renderer expose coherent adaptive metadata for both migrated signatures', async () => {
+  for (const preset of PRESETS) {
+    const catalogEntry = resolveMarkdownTheme(preset.id);
+    const document = await renderMarkdown('# Adaptive signature\n\nPlain body.', preset.id);
+    const baselinePosition = document.indexOf('/css/markdown-theme-baseline.css');
+    const signaturePosition = document.indexOf(`/css/markdown-${preset.id}.css`);
+
+    assert.equal(catalogEntry.appearances.light.canvas, preset.lightCanvas);
+    assert.equal(catalogEntry.appearances.dark.canvas, preset.darkCanvas);
+    assert.notEqual(catalogEntry.appearances.light.canvas, catalogEntry.appearances.dark.canvas);
+    assert.ok(baselinePosition >= 0);
+    assert.ok(signaturePosition > baselinePosition);
+    assert.match(document, new RegExp(`data-markdown-theme="${preset.id}"`));
+    assert.match(document, new RegExp(`content="${preset.lightCanvas}" media="\\(prefers-color-scheme: light\\)"`));
+    assert.match(document, new RegExp(`content="${preset.darkCanvas}" media="\\(prefers-color-scheme: dark\\)"`));
+    assert.equal((document.match(/markdown-theme-baseline\.css/g) || []).length, 1);
+    assert.equal((document.match(new RegExp(`markdown-${preset.id}\\.css`, 'g')) || []).length, 1);
+    assert.doesNotMatch(document, /fonts\.googleapis\.com/);
+  }
+});
+
+test('GitHub and Apple round-trip unchanged through preview, browser/API writes, metadata, admin edit, and public rendering', async () => {
+  for (const [index, preset] of PRESETS.entries()) {
+    const preview = await jsonRequest('/api/pages/preview', 'POST', {
+      htmlContent: `# ${preset.id} preview`,
+      codeType: 'markdown',
+      markdownTheme: preset.id
+    });
+    assert.equal(preview.status, 200);
+    assert.match(preview.body.document, new RegExp(`data-markdown-theme=(?:"|&quot;)${preset.id}(?:"|&quot;)`));
+
+    const browserCreate = await jsonRequest('/api/pages/create', 'POST', {
+      htmlContent: `# ${preset.id} browser create`,
+      codeType: 'markdown',
+      title: `${preset.id} title`,
+      description: `${preset.id} description`,
+      markdownTheme: preset.id
+    });
+    assert.equal(browserCreate.status, 200);
+    assert.equal(browserCreate.body.markdownTheme, preset.id);
+
+    const browserStored = await app.locals.pageRepository.getById(browserCreate.body.urlId);
+    const metadata = await request(`/api/pages/${browserCreate.body.urlId}`);
+    const publicView = await request(`/view/${browserCreate.body.urlId}`);
+    assert.equal(browserStored.markdown_theme, preset.id);
+    assert.equal(metadata.body.page.markdownTheme, preset.id);
+    assert.match(publicView.text, new RegExp(`data-markdown-theme=(?:"|&quot;)${preset.id}(?:"|&quot;)`));
+    assert.match(publicView.text, new RegExp(`/css/markdown-${preset.id}\\.css`));
+
+    const apiCreate = await jsonRequest('/api/v1/share', 'POST', {
+      htmlContent: `# ${preset.id} API create`,
+      codeType: 'markdown',
+      markdownTheme: preset.id
+    }, { 'X-API-Key': 'markdown-theme-signatures-12-key' });
+    assert.equal(apiCreate.status, 200);
+    assert.equal(apiCreate.body.markdownTheme, preset.id);
+    assert.equal((await app.locals.pageRepository.getById(apiCreate.body.urlId)).markdown_theme, preset.id);
+
+    const otherPreset = PRESETS[(index + 1) % PRESETS.length];
+    const adminSource = await jsonRequest('/api/pages/create', 'POST', {
+      htmlContent: `# Preserve ${preset.id}`,
+      codeType: 'markdown',
+      title: `Preserve ${preset.id} title`,
+      description: `Preserve ${preset.id} description`,
+      markdownTheme: otherPreset.id
+    });
+    const adminUpdate = await jsonRequest(`/admin/pages/${adminSource.body.urlId}`, 'PUT', {
+      markdownTheme: preset.id
+    });
+    const adminStored = await app.locals.pageRepository.getById(adminSource.body.urlId);
+    assert.equal(adminUpdate.status, 200);
+    assert.equal(adminUpdate.body.page.markdownTheme, preset.id);
+    assert.equal(adminStored.markdown_theme, preset.id);
+    assert.equal(adminStored.html_content, `# Preserve ${preset.id}`);
+    assert.equal(adminStored.title, `Preserve ${preset.id} title`);
+    assert.equal(adminStored.description, `Preserve ${preset.id} description`);
+  }
+});

--- a/test/markdown-theme-tesla-bugatti.test.js
+++ b/test/markdown-theme-tesla-bugatti.test.js
@@ -1,0 +1,215 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'tesla-bugatti-theme-key';
+process.env.SESSION_SECRET = 'tesla-bugatti-theme-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const {
+  MARKDOWN_THEME_CATALOG,
+  getMarkdownThemeOptions,
+  resolveMarkdownTheme
+} = require('../utils/markdownThemeCatalog');
+
+const THEMES = [
+  {
+    id: 'tesla',
+    label: 'Tesla 黑白',
+    light: '#ffffff',
+    dark: '#050505'
+  },
+  {
+    id: 'bugatti',
+    label: 'Bugatti 蓝曜',
+    light: '#f4f8fc',
+    dark: '#0b0e12'
+  }
+];
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+async function seedMarkdownShare(id) {
+  await app.locals.pageRepository.create({
+    id,
+    htmlContent: '# Engineering Notes\n\n[Focused link](https://example.com)\n\n| Metric | Value |\n| --- | --- |\n| Width | bounded |',
+    createdAt: Date.now(),
+    passwordHash: null,
+    encryptedPassword: null,
+    isProtected: false,
+    codeType: 'markdown',
+    title: id,
+    description: 'Tesla and Bugatti theme acceptance',
+    expiresAt: null,
+    markdownTheme: 'bytedance'
+  });
+}
+
+function readSignature(id) {
+  return fs.readFileSync(path.join(__dirname, `../public/css/markdown-${id}.css`), 'utf8');
+}
+
+test('Tesla and Bugatti occupy their formal relative Catalog order with trusted adaptive metadata', () => {
+  const canonicalOrder = [
+    'bytedance', 'github', 'apple', 'notion', 'claude', 'raycast',
+    'google', 'tesla', 'airbnb', 'bugatti', 'linear', 'playstation'
+  ];
+  const ids = MARKDOWN_THEME_CATALOG.map(({ id }) => id);
+
+  assert.deepEqual(ids, canonicalOrder.filter(id => ids.includes(id)));
+
+  for (const expected of THEMES) {
+    const entry = resolveMarkdownTheme(expected.id);
+    assert.equal(entry.id, expected.id);
+    assert.equal(entry.label, expected.label);
+    assert.equal(entry.signatureHref, `/css/markdown-${expected.id}.css`);
+    assert.equal(entry.appearances.light.canvas, expected.light);
+    assert.equal(entry.appearances.dark.canvas, expected.dark);
+    assert.equal(getMarkdownThemeOptions().some(option => option.id === expected.id), true);
+  }
+});
+
+test('Tesla and Bugatti render only their trusted local signatures after the shared baseline', async () => {
+  for (const { id, light, dark } of THEMES) {
+    const html = await renderMarkdown('# Signature\n\nPlain local content.', id);
+    const baselinePosition = html.indexOf('/css/markdown-theme-baseline.css');
+    const signaturePosition = html.indexOf(`/css/markdown-${id}.css`);
+
+    assert.ok(baselinePosition >= 0);
+    assert.ok(signaturePosition > baselinePosition);
+    assert.match(html, new RegExp(`data-markdown-theme="${id}"`));
+    assert.match(html, new RegExp(`--theme-canvas: ${light}`));
+    assert.match(html, new RegExp(`--theme-canvas: ${dark}`));
+    assert.doesNotMatch(html, /fonts\.googleapis\.com|https?:\/\/[^"']+\.(?:css|woff2?|png|jpe?g|webp|svg)/i);
+  }
+});
+
+test('Tesla signature keeps hard monochrome hierarchy and a smaller compact Sampler heading', () => {
+  const css = readSignature('tesla');
+  const longForm = css.match(/\.markdown-body h1\s*\{[^}]*font-size:\s*clamp\([^,]+,[^,]+,\s*([0-9.]+)rem\)/s);
+  const sampler = css.match(/\.theme-sampler \.markdown-body h1\s*\{[^}]*font-size:\s*clamp\([^,]+,[^,]+,\s*([0-9.]+)rem\)/s);
+
+  assert.match(css, /--theme-canvas:\s*#ffffff/i);
+  assert.match(css, /--theme-text:\s*#050505/i);
+  assert.match(css, /\.markdown-body h1\s*\{[^}]*text-transform:\s*uppercase/s);
+  assert.match(css, /\.markdown-body h1\s*\{[^}]*border-(?:top|block-start):\s*1px solid/s);
+  assert.match(css, /\.markdown-body h1\s*\{[^}]*border-(?:bottom|block-end):\s*1px solid/s);
+  assert.ok(longForm, 'Tesla long-form h1 must declare a clamp scale');
+  assert.ok(sampler, 'Tesla Theme Sampler h1 must declare its compact clamp scale');
+  assert.ok(Number(sampler[1]) < Number(longForm[1]), 'Sampler maximum must be smaller than long-form maximum');
+  assert.match(css, /@media \(prefers-color-scheme:\s*dark\)/);
+});
+
+test('Bugatti signature uses ice/carbon polarity, vivid blue focus, metallic rules, and one restrained facet', () => {
+  const css = readSignature('bugatti');
+
+  assert.match(css, /--theme-canvas:\s*#f4f8fc/i);
+  assert.match(css, /--theme-carbon:\s*#0b0e12/i);
+  assert.match(css, /--theme-focus:\s*#0057ff/i);
+  assert.match(css, /--theme-metal:/i);
+  assert.match(css, /border[^;]*1px solid var\(--theme-metal\)/i);
+  assert.equal((css.match(/clip-path:\s*polygon\(/gi) || []).length, 1);
+  assert.match(css, /@media \(prefers-color-scheme:\s*dark\)/);
+});
+
+test('both signatures use system fonts and contain no remote, animated, textured, or shine effects', () => {
+  for (const { id } of THEMES) {
+    const css = readSignature(id);
+
+    assert.match(css, /font-family:[^;]*(?:ui-sans-serif|-apple-system|BlinkMacSystemFont|Segoe UI)/i);
+    assert.doesNotMatch(css, /@import|@font-face|url\s*\(|https?:|@keyframes|animation\s*:|filter\s*:|background-image\s*:|box-shadow\s*:/i);
+  }
+});
+
+test('preview, browser/API creation, metadata, admin update, and public rendering round-trip both IDs', async () => {
+  for (const { id } of THEMES) {
+    const preview = await jsonRequest('/api/pages/preview', 'POST', {
+      htmlContent: '# Preview',
+      codeType: 'markdown',
+      markdownTheme: id
+    });
+    assert.equal(preview.status, 200);
+    assert.match(preview.body.document, new RegExp(`markdown-${id}\\.css`));
+
+    const created = await jsonRequest('/api/pages/create', 'POST', {
+      htmlContent: `# Browser ${id}`,
+      codeType: 'markdown',
+      markdownTheme: id
+    });
+    assert.equal(created.status, 200);
+    assert.equal(created.body.markdownTheme, id);
+
+    const metadata = await request(`/api/pages/${created.body.urlId}`);
+    assert.equal(metadata.status, 200);
+    assert.equal(metadata.body.page.markdownTheme, id);
+
+    const publicView = await request(`/view/${created.body.urlId}`);
+    assert.equal(publicView.status, 200);
+    assert.match(publicView.text, new RegExp(`markdown-${id}\\.css`));
+    assert.doesNotMatch(publicView.text, /fonts\.googleapis\.com/);
+
+    const apiCreated = await jsonRequest('/api/v1/share', 'POST', {
+      htmlContent: `# API ${id}`,
+      codeType: 'markdown',
+      markdownTheme: id
+    }, { 'X-API-Key': 'tesla-bugatti-theme-key' });
+    assert.equal(apiCreated.status, 200);
+    assert.equal(apiCreated.body.markdownTheme, id);
+
+    const adminId = `issue-17-admin-${id}`;
+    await seedMarkdownShare(adminId);
+    const adminUpdate = await jsonRequest(`/admin/pages/${adminId}`, 'PUT', { markdownTheme: id });
+    const stored = await app.locals.pageRepository.getById(adminId);
+    assert.equal(adminUpdate.status, 200);
+    assert.equal(adminUpdate.body.page.markdownTheme, id);
+    assert.equal(stored.markdown_theme, id);
+  }
+});

--- a/test/markdown-theme-ticket-15.test.js
+++ b/test/markdown-theme-ticket-15.test.js
@@ -1,0 +1,351 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SHARE_API_KEY = 'markdown-theme-ticket-15-key';
+process.env.SESSION_SECRET = 'markdown-theme-ticket-15-secret';
+
+const app = require('../app');
+const { renderMarkdown } = require('../utils/contentRenderer');
+const {
+  MARKDOWN_THEME_CATALOG,
+  resolveMarkdownTheme
+} = require('../utils/markdownThemeCatalog');
+
+const TICKET_THEMES = [
+  ['raycast', 'Raycast 专注'],
+  ['linear', 'Linear 精密']
+];
+
+let server;
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+function request(route, options = {}) {
+  return new Promise((resolve, reject) => {
+    const body = options.body || '';
+    const req = http.request(new URL(route, baseUrl), {
+      method: options.method || 'GET',
+      headers: {
+        ...(body ? { 'Content-Length': Buffer.byteLength(body) } : {}),
+        ...(options.headers || {})
+      }
+    }, (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        text,
+        body: res.headers['content-type']?.includes('application/json') ? JSON.parse(text) : null
+      }));
+    });
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+function jsonRequest(route, method, value, headers = {}) {
+  return request(route, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(value)
+  });
+}
+
+const SEMANTIC_TOKENS = [
+  'canvas',
+  'text',
+  'muted',
+  'accent',
+  'link',
+  'border',
+  'quote-surface',
+  'table-surface',
+  'diagram-surface',
+  'diagram-text',
+  'diagram-node-surface',
+  'diagram-node-border',
+  'diagram-line',
+  'diagram-label-surface',
+  'code-text',
+  'code-surface',
+  'focus',
+  'heading-on-accent'
+];
+
+function readSignature(id) {
+  return fs.readFileSync(
+    path.join(__dirname, `../public/css/markdown-${id}.css`),
+    'utf8'
+  );
+}
+
+function rootDeclarations(css) {
+  const match = css.match(/^\s*:root\s*\{([^}]*)\}/s);
+  assert.ok(match, 'signature must start with a light :root token set');
+  return match[1];
+}
+
+function darkDeclarations(css) {
+  const match = css.match(/@media\s*\(prefers-color-scheme:\s*dark\)\s*\{[\s\S]*?:root\s*\{([^}]*)\}/);
+  assert.ok(match, 'signature must define a dark :root token set');
+  return match[1];
+}
+
+function tokenValue(declarations, token) {
+  const match = declarations.match(new RegExp(`--theme-${token}:\\s*([^;]+);`));
+  assert.ok(match, `missing --theme-${token}`);
+  return match[1].trim();
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace('#', '');
+  return [0, 2, 4].map(offset => Number.parseInt(value.slice(offset, offset + 2), 16));
+}
+
+function relativeLuminance(hex) {
+  return hexToRgb(hex)
+    .map(channel => channel / 255)
+    .map(channel => channel <= 0.04045
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4)
+    .reduce((sum, channel, index) => sum + channel * [0.2126, 0.7152, 0.0722][index], 0);
+}
+
+function contrast(first, second) {
+  const [lighter, darker] = [relativeLuminance(first), relativeLuminance(second)]
+    .sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function saturation(hex) {
+  const [red, green, blue] = hexToRgb(hex).map(channel => channel / 255);
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const lightness = (max + min) / 2;
+  return max === min ? 0 : (max - min) / (1 - Math.abs(2 * lightness - 1));
+}
+
+test('Issue #15 registers Raycast and Linear in their relative formal Catalog order', () => {
+  const ticketEntries = MARKDOWN_THEME_CATALOG
+    .filter(({ id }) => TICKET_THEMES.some(([ticketId]) => ticketId === id))
+    .map(({ id, label }) => [id, label]);
+
+  assert.deepEqual(ticketEntries, TICKET_THEMES);
+  assert.equal(resolveMarkdownTheme('raycast').signatureHref, '/css/markdown-raycast.css');
+  assert.equal(resolveMarkdownTheme('linear').signatureHref, '/css/markdown-linear.css');
+});
+
+test('Issue #15 signatures provide complete light and dark semantic token sets with accessible role contrast', () => {
+  const contrastPairs = [
+    ['text', 'canvas', 4.5],
+    ['muted', 'canvas', 4.5],
+    ['link', 'canvas', 4.5],
+    ['muted', 'quote-surface', 4.5],
+    ['text', 'table-surface', 4.5],
+    ['diagram-text', 'diagram-surface', 4.5],
+    ['diagram-text', 'diagram-node-surface', 4.5],
+    ['code-text', 'code-surface', 4.5],
+    ['focus', 'canvas', 3]
+  ];
+
+  for (const [id] of TICKET_THEMES) {
+    const css = readSignature(id);
+
+    for (const declarations of [rootDeclarations(css), darkDeclarations(css)]) {
+      for (const token of SEMANTIC_TOKENS) {
+        assert.match(tokenValue(declarations, token), /^#[0-9a-f]{6}$/i);
+      }
+
+      for (const [foreground, background, minimum] of contrastPairs) {
+        assert.ok(
+          contrast(tokenValue(declarations, foreground), tokenValue(declarations, background)) >= minimum,
+          `${id} ${foreground}/${background} contrast must be at least ${minimum}:1`
+        );
+      }
+    }
+  }
+});
+
+test('Issue #15 signatures use only local static system-font CSS', () => {
+  for (const [id] of TICKET_THEMES) {
+    const css = readSignature(id);
+
+    assert.match(css, /--theme-font-family:\s*ui-sans-serif,/);
+    assert.doesNotMatch(css, /@import|@font-face|url\s*\(|https?:|fonts\.|\.woff2?|\.ttf|\.otf/i);
+    assert.doesNotMatch(css, /@keyframes|animation\s*:|transition\s*:|filter\s*:|backdrop-filter|text-shadow/i);
+  }
+});
+
+test('Issue #15 keeps Raycast deeper and more plum-tonal while Linear stays flatter and denser', () => {
+  const raycast = readSignature('raycast');
+  const linear = readSignature('linear');
+  const raycastLight = rootDeclarations(raycast);
+  const linearLight = rootDeclarations(linear);
+
+  assert.equal(tokenValue(raycastLight, 'surface-radius'), '12px');
+  assert.equal(tokenValue(linearLight, 'surface-radius'), '7px');
+  assert.equal(tokenValue(raycastLight, 'body-size'), '16px');
+  assert.equal(tokenValue(linearLight, 'body-size'), '15px');
+  assert.match(tokenValue(raycastLight, 'surface-shadow'), /^inset /);
+  assert.equal(tokenValue(linearLight, 'surface-shadow'), 'none');
+  assert.ok(
+    saturation(tokenValue(raycastLight, 'accent')) > saturation(tokenValue(linearLight, 'accent')),
+    'Raycast accent must be more saturated than Linear accent'
+  );
+  assert.ok(
+    Math.abs(relativeLuminance(tokenValue(raycastLight, 'tool-surface')) - relativeLuminance(tokenValue(raycastLight, 'canvas')))
+      > Math.abs(relativeLuminance(tokenValue(linearLight, 'tool-surface')) - relativeLuminance(tokenValue(linearLight, 'canvas'))),
+    'Raycast tool surface must have more tonal depth than Linear tool surface'
+  );
+  assert.match(raycast, /box-shadow:\s*var\(--theme-surface-shadow\)/);
+  assert.doesNotMatch(linear, /box-shadow\s*:/);
+});
+
+test('Issue #15 signatures keep diagram geometry above the renderer runtime defaults', () => {
+  for (const [id, radius] of [['raycast', '12px'], ['linear', '7px']]) {
+    const css = readSignature(id);
+
+    assert.match(
+      css,
+      /\.markdown-body\s+\.mermaid,[\s\S]*?\.markdown-body\s+\.embedded-mermaid-container\s*\{[^}]*border-radius:\s*var\(--theme-surface-radius\)/
+    );
+    assert.equal(tokenValue(rootDeclarations(css), 'surface-radius'), radius);
+  }
+});
+
+test('Issue #15 renderer uses exactly one trusted signature and keeps optional runtimes conditional', async () => {
+  for (const [id] of TICKET_THEMES) {
+    const otherId = id === 'raycast' ? 'linear' : 'raycast';
+    const plain = await renderMarkdown('# Focused report\n\nPlain Markdown.', id);
+    const code = await renderMarkdown('```js\nconst precise = true;\n```', id);
+    const diagram = await renderMarkdown('```mermaid\ngraph LR\nFocus --> Ship\n```', id);
+
+    assert.match(plain, new RegExp(`data-markdown-theme="${id}"`));
+    assert.equal((plain.match(/markdown-theme-baseline\.css/g) || []).length, 1);
+    assert.equal((plain.match(new RegExp(`markdown-${id}\\.css`, 'g')) || []).length, 1);
+    assert.doesNotMatch(plain, new RegExp(`markdown-${otherId}\\.css`));
+    assert.doesNotMatch(plain, /mermaid\.min\.js|highlight\.min\.js/);
+    assert.match(code, /highlight\.min\.js/);
+    assert.doesNotMatch(code, /mermaid\.min\.js/);
+    assert.match(diagram, /mermaid\.min\.js/);
+    assert.doesNotMatch(diagram, /highlight\.min\.js/);
+  }
+});
+
+test('Issue #15 carries both IDs through preview, browser/API persistence, metadata, admin, and public rendering', async () => {
+  const homepage = await request('/');
+
+  assert.equal(homepage.status, 200);
+
+  for (const [id, label] of TICKET_THEMES) {
+    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+
+    const preview = await jsonRequest('/api/pages/preview', 'POST', {
+      htmlContent: `# ${label} preview`,
+      codeType: 'markdown',
+      markdownTheme: id
+    });
+    assert.equal(preview.status, 200);
+    assert.match(preview.body.document, new RegExp(`data-markdown-theme=&quot;${id}&quot;`));
+    assert.match(preview.body.document, new RegExp(`markdown-${id}\\.css`));
+
+    const browserCreate = await jsonRequest('/api/pages/create', 'POST', {
+      htmlContent: `# ${label} browser`,
+      codeType: 'markdown',
+      title: `${label} browser title`,
+      description: `${label} browser description`,
+      markdownTheme: id
+    });
+    assert.equal(browserCreate.status, 200);
+    assert.equal(browserCreate.body.markdownTheme, id);
+
+    const apiCreate = await jsonRequest('/api/v1/share', 'POST', {
+      htmlContent: `# ${label} API`,
+      codeType: 'markdown',
+      markdownTheme: id
+    }, { 'X-API-Key': 'markdown-theme-ticket-15-key' });
+    assert.equal(apiCreate.status, 200);
+    assert.equal(apiCreate.body.markdownTheme, id);
+
+    const metadata = await request(`/api/pages/${browserCreate.body.urlId}`);
+    assert.equal(metadata.status, 200);
+    assert.equal(metadata.body.page.markdownTheme, id);
+
+    const admin = await request(`/admin/pages/${browserCreate.body.urlId}`);
+    assert.equal(admin.status, 200);
+    assert.match(admin.text, new RegExp(`<option value="${id}" selected>${label}</option>`));
+
+    const update = await jsonRequest(`/admin/pages/${browserCreate.body.urlId}`, 'PUT', {
+      markdownTheme: id
+    });
+    assert.equal(update.status, 200);
+    assert.equal(update.body.page.markdownTheme, id);
+
+    const stored = await app.locals.pageRepository.getById(browserCreate.body.urlId);
+    assert.equal(stored.markdown_theme, id);
+    assert.equal(stored.title, `${label} browser title`);
+    assert.equal(stored.description, `${label} browser description`);
+
+    const publicView = await request(`/view/${apiCreate.body.urlId}`);
+    assert.equal(publicView.status, 200);
+    assert.match(publicView.text, new RegExp(`data-markdown-theme=&quot;${id}&quot;`));
+    assert.match(publicView.text, new RegExp(`markdown-${id}\\.css`));
+  }
+});
+
+test('Issue #15 theme-only edits preserve every unrelated Share field for both target IDs', async () => {
+  for (const [targetId] of TICKET_THEMES) {
+    const sourceId = targetId === 'raycast' ? 'linear' : 'raycast';
+    const shareId = `ticket-15-preserve-${targetId}`;
+    const expiresAt = Date.now() + 86_400_000;
+
+    await app.locals.pageRepository.create({
+      id: shareId,
+      htmlContent: `# Preserve ${targetId}`,
+      createdAt: Date.now(),
+      passwordHash: `${targetId}-password-hash`,
+      encryptedPassword: `${targetId}-encrypted-password`,
+      isProtected: true,
+      codeType: 'markdown',
+      title: `${targetId} preserved title`,
+      description: `${targetId} preserved description`,
+      expiresAt,
+      markdownTheme: sourceId
+    });
+    const before = await app.locals.pageRepository.getById(shareId);
+    before.is_favorite = true;
+    before.view_count = 15;
+
+    const response = await jsonRequest(`/admin/pages/${shareId}`, 'PUT', {
+      markdownTheme: targetId
+    });
+    const stored = await app.locals.pageRepository.getById(shareId);
+
+    assert.equal(response.status, 200);
+    assert.equal(stored.markdown_theme, targetId);
+    assert.equal(stored.html_content, `# Preserve ${targetId}`);
+    assert.equal(stored.title, `${targetId} preserved title`);
+    assert.equal(stored.description, `${targetId} preserved description`);
+    assert.equal(stored.password_hash, `${targetId}-password-hash`);
+    assert.equal(stored.encrypted_password, `${targetId}-encrypted-password`);
+    assert.equal(stored.is_protected, 1);
+    assert.equal(stored.expires_at, expiresAt);
+    assert.equal(stored.is_favorite, true);
+    assert.equal(stored.view_count, 15);
+  }
+});

--- a/test/markdown-theme-ticket-15.test.js
+++ b/test/markdown-theme-ticket-15.test.js
@@ -253,7 +253,7 @@ test('Issue #15 carries both IDs through preview, browser/API persistence, metad
   assert.equal(homepage.status, 200);
 
   for (const [id, label] of TICKET_THEMES) {
-    assert.match(homepage.text, new RegExp(`<option value="${id}"[^>]*>${label}</option>`));
+    assert.match(homepage.text, new RegExp(`<option\\b(?=[^>]*value="${id}")[^>]*>\\s*${label}</option>`));
 
     const preview = await jsonRequest('/api/pages/preview', 'POST', {
       htmlContent: `# ${label} preview`,
@@ -288,7 +288,7 @@ test('Issue #15 carries both IDs through preview, browser/API persistence, metad
 
     const admin = await request(`/admin/pages/${browserCreate.body.urlId}`);
     assert.equal(admin.status, 200);
-    assert.match(admin.text, new RegExp(`<option value="${id}" selected>${label}</option>`));
+    assert.match(admin.text, new RegExp(`<option\\b(?=[^>]*value="${id}")(?=[^>]*selected)[^>]*>\\s*${label}</option>`));
 
     const update = await jsonRequest(`/admin/pages/${browserCreate.body.urlId}`, 'PUT', {
       markdownTheme: id

--- a/test/theme-sampler.test.js
+++ b/test/theme-sampler.test.js
@@ -1,0 +1,186 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+process.env.NODE_ENV = 'test';
+process.env.AUTH_ENABLED = 'false';
+process.env.SESSION_SECRET = 'theme-sampler-secret';
+
+const app = require('../app');
+const { getMarkdownThemeOptions } = require('../utils/markdownThemeCatalog');
+
+let server;
+let baseUrl;
+
+function request(route) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(new URL(route, baseUrl), (res) => {
+      let text = '';
+      res.on('data', chunk => { text += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode, text }));
+    });
+    req.on('error', reject);
+  });
+}
+
+test.before(async () => {
+  await app.locals.pageRepository.create({
+    id: 'sampler-markdown',
+    htmlContent: '# Stored Markdown',
+    createdAt: Date.now(),
+    passwordHash: null,
+    encryptedPassword: null,
+    isProtected: false,
+    codeType: 'markdown',
+    title: 'Sampler Markdown',
+    description: null,
+    expiresAt: null,
+    markdownTheme: 'github'
+  });
+  await app.locals.pageRepository.create({
+    id: 'sampler-html',
+    htmlContent: '<h1>Stored HTML</h1>',
+    createdAt: Date.now(),
+    passwordHash: null,
+    encryptedPassword: null,
+    isProtected: false,
+    codeType: 'html',
+    title: 'Sampler HTML',
+    description: null,
+    expiresAt: null,
+    markdownTheme: null
+  });
+
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://localhost:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+test.after(() => server.close());
+
+test('homepage projects every Catalog option into one labeled fixed Sampler', async () => {
+  const homepage = await request('/');
+
+  assert.equal(homepage.status, 200);
+  assert.match(homepage.text, /id="markdown-theme-selector"[^>]+hidden/);
+  assert.match(homepage.text, /<label[^>]+for="markdown-theme"[^>]*>Markdown 主题<\/label>/);
+  assert.match(homepage.text, /id="markdown-theme"[^>]+aria-controls="markdown-theme-sampler"/);
+  assert.match(homepage.text, /data-theme-sampler[^>]+aria-label="ByteDance 蓝绿主题样例"/);
+  assert.match(homepage.text, /id="markdown-theme-sampler"[^>]+data-theme-sampler-frame[^>]+title="ByteDance 蓝绿主题样例"[^>]+tabindex="-1"/);
+  assert.match(homepage.text, /src="\/js\/theme-sampler\.js"/);
+
+  for (const { id } of getMarkdownThemeOptions()) {
+    assert.match(
+      homepage.text,
+      new RegExp(
+        `<option\\b(?=[^>]*value="${id}")(?=[^>]*data-signature-href="/css/markdown-${id}\\.css")[^>]*>`
+      )
+    );
+  }
+});
+
+test('the fixed sample covers the agreed roles without editable or runtime content', () => {
+  const sampler = fs.readFileSync(
+    path.join(__dirname, '../views/partials/theme-sampler.ejs'),
+    'utf8'
+  );
+
+  for (const role of [
+    'heading',
+    'body',
+    'emphasis',
+    'link',
+    'list',
+    'quotation',
+    'inline-code',
+    'fenced-code',
+    'table',
+    'task',
+    'keyboard',
+    'image',
+    'divider',
+    'diagram'
+  ]) {
+    assert.match(sampler, new RegExp(`data-sample-role="${role}"`));
+  }
+
+  assert.doesNotMatch(sampler, /textarea|contenteditable|html-input|rendered-preview/i);
+  assert.doesNotMatch(sampler, /https?:\/\/|mermaid(?:\.min)?\.js|highlight(?:\.min)?\.js/i);
+});
+
+test('Sampler controller swaps only trusted local styles and never requests full preview', () => {
+  const script = fs.readFileSync(
+    path.join(__dirname, '../public/js/theme-sampler.js'),
+    'utf8'
+  );
+
+  assert.match(script, /selectedOptions\[0\]/);
+  assert.match(script, /dataset\.signatureHref/);
+  assert.match(script, /\/css\/markdown-theme-baseline\.css/);
+  assert.match(script, /frame\.srcdoc/);
+  assert.match(script, /frame\.title/);
+  assert.doesNotMatch(script, /fetch\s*\(|\/api\/pages\/preview|html-input|content-textarea/i);
+  assert.doesNotMatch(script, /https?:\/\/|mermaid|hljs|highlight\.js/i);
+
+  const claudeSignature = fs.readFileSync(
+    path.join(__dirname, '../public/css/markdown-claude.css'),
+    'utf8'
+  );
+  assert.doesNotMatch(claudeSignature, /@import|https?:\/\//i);
+});
+
+test('homepage preference is validated against Catalog options and storage failures are silent', () => {
+  const script = fs.readFileSync(path.join(__dirname, '../public/js/main.js'), 'utf8');
+
+  assert.match(script, /quickshare:creator-markdown-theme/);
+  assert.match(script, /localStorage\.getItem/);
+  assert.match(script, /localStorage\.setItem/);
+  assert.match(script, /catch \(error\) \{[\s\S]*?return 'bytedance';/);
+  assert.match(script, /Array\.from\(markdownThemeSelect\.options\)/);
+  assert.match(script, /option\.value === value/);
+  assert.doesNotMatch(script, /JSON\.parse\([^)]*localStorage/);
+});
+
+test('admin Markdown edit uses stored theme and Sampler without Creator Theme Preference', async () => {
+  const [markdown, html] = await Promise.all([
+    request('/admin/pages/sampler-markdown'),
+    request('/admin/pages/sampler-html')
+  ]);
+  const adminScript = fs.readFileSync(
+    path.join(__dirname, '../public/js/admin-detail.js'),
+    'utf8'
+  );
+
+  assert.equal(markdown.status, 200);
+  assert.match(
+    markdown.text,
+    /<option\b(?=[^>]*value="github")(?=[^>]*selected)[^>]*>GitHub 经典<\/option>/
+  );
+  assert.match(markdown.text, /data-theme-sampler[^>]+aria-label="GitHub 经典主题样例"/);
+  assert.match(markdown.text, /src="\/js\/theme-sampler\.js"/);
+  assert.doesNotMatch(html.text, /data-theme-sampler/);
+  assert.doesNotMatch(adminScript, /localStorage|quickshare:creator-markdown-theme/);
+});
+
+test('site CSS keeps the sampler compact, focused, and vertically stacked at 375 px', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../public/css/styles.css'), 'utf8');
+
+  assert.match(css, /\.theme-sampler-settings\s*\{[^}]*display:\s*grid/s);
+  assert.match(css, /\.theme-sampler-settings\.hidden\s*\{[^}]*display:\s*none/s);
+  assert.match(css, /\.theme-select:focus-visible\s*\{[^}]*outline:/s);
+  assert.match(css, /#theme-field \.theme-select:focus-visible\s*\{[^}]*outline:/s);
+  assert.match(css, /\.theme-sampler-frame\s*\{[^}]*width:\s*100%[^}]*border:/s);
+  assert.match(
+    css,
+    /@media \(max-width:\s*480px\)[\s\S]*?\.theme-sampler-settings\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s
+  );
+  assert.match(
+    fs.readFileSync(path.join(__dirname, '../public/js/theme-sampler.js'), 'utf8'),
+    /@media \(max-width:\s*420px\)[\s\S]*?\.theme-sampler-diagram\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)/s
+  );
+});

--- a/utils/contentRenderer.js
+++ b/utils/contentRenderer.js
@@ -7,68 +7,8 @@ const { marked } = require('marked');
 const { CODE_TYPES } = require('./codeDetector');
 const {
   MARKDOWN_THEME_BASELINE_HREF,
-  MARKDOWN_THEME_CATALOG,
-  resolveMarkdownTheme,
-  resolveMarkdownThemeId
+  resolveMarkdownTheme
 } = require('./markdownThemeCatalog');
-
-const MARKDOWN_THEMES = Object.freeze(Object.fromEntries(
-  MARKDOWN_THEME_CATALOG.map(({ id, signatureHref }) => [id, signatureHref])
-));
-
-const MERMAID_LIGHT_THEME = {
-  darkMode: false,
-  background: '#ffffff',
-  fontFamily: '"Inter", "SF Pro Display", system-ui, -apple-system, sans-serif',
-  fontSize: '14px',
-  primaryColor: '#EEF2FF',
-  primaryTextColor: '#1e293b',
-  primaryBorderColor: '#6366f1',
-  secondaryColor: '#F0FDF4',
-  tertiaryColor: '#F8FAFC',
-  lineColor: '#94a3b8',
-  mainBkg: '#EEF2FF',
-  nodeBorder: '#6366f1',
-  clusterBkg: '#F8FAFC',
-  clusterBorder: '#e2e8f0',
-  defaultLinkColor: '#6366f1',
-  titleColor: '#0f172a',
-  edgeLabelBackground: '#ffffff',
-  nodeTextColor: '#1e293b',
-  useGradient: true,
-  gradientStart: '#EEF2FF',
-  gradientStop: '#E0E7FF',
-  dropShadow: 'drop-shadow(0px 2px 4px rgba(99, 102, 241, 0.12))',
-  radius: 10,
-  strokeWidth: 2,
-};
-
-const MERMAID_DARK_THEME = {
-  darkMode: true,
-  background: '#0f172a',
-  fontFamily: '"Inter", "SF Pro Display", system-ui, -apple-system, sans-serif',
-  fontSize: '14px',
-  primaryColor: '#1e293b',
-  primaryTextColor: '#e2e8f0',
-  primaryBorderColor: '#6366f1',
-  secondaryColor: '#1e3a5f',
-  tertiaryColor: '#0f172a',
-  lineColor: '#64748b',
-  mainBkg: '#1e293b',
-  nodeBorder: '#6366f1',
-  clusterBkg: '#1e293b',
-  clusterBorder: '#334155',
-  defaultLinkColor: '#818cf8',
-  titleColor: '#f1f5f9',
-  edgeLabelBackground: '#1e293b',
-  nodeTextColor: '#e2e8f0',
-  useGradient: true,
-  gradientStart: '#1e293b',
-  gradientStop: '#1e3a5f',
-  dropShadow: 'drop-shadow(0px 2px 6px rgba(0, 0, 0, 0.4))',
-  radius: 10,
-  strokeWidth: 2,
-};
 
 const MERMAID_THEME_CSS = `
   .node rect, .node circle, .node polygon { rx: 10; ry: 10; }
@@ -76,6 +16,34 @@ const MERMAID_THEME_CSS = `
   .label { font-weight: 500; }
   .cluster rect { rx: 12; }
 `;
+
+const STANDALONE_MERMAID_LIGHT_THEME = {
+  darkMode: false,
+  background: '#ffffff',
+  primaryColor: '#eef2ff',
+  primaryTextColor: '#1e293b',
+  primaryBorderColor: '#6366f1',
+  secondaryColor: '#f0fdf4',
+  tertiaryColor: '#f8fafc',
+  lineColor: '#94a3b8',
+  clusterBorder: '#e2e8f0',
+  defaultLinkColor: '#6366f1',
+  titleColor: '#0f172a'
+};
+
+const STANDALONE_MERMAID_DARK_THEME = {
+  darkMode: true,
+  background: '#0f172a',
+  primaryColor: '#1e293b',
+  primaryTextColor: '#e2e8f0',
+  primaryBorderColor: '#6366f1',
+  secondaryColor: '#1e3a5f',
+  tertiaryColor: '#0f172a',
+  lineColor: '#64748b',
+  clusterBorder: '#334155',
+  defaultLinkColor: '#818cf8',
+  titleColor: '#f1f5f9'
+};
 
 const MERMAID_CDN = 'https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.min.js';
 const HIGHLIGHT_CSS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css';
@@ -277,10 +245,58 @@ async function renderMarkdown(content, theme) {
   <script>
     // 配置 Mermaid
     document.addEventListener('DOMContentLoaded', function() {
-      // 检测暗色模式
-      const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const appearanceQuery = window.matchMedia
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : { matches: false };
 
       try {
+        const themeToken = function(name, fallback) {
+          const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+          return value || fallback;
+        };
+
+        const mermaidThemeVariables = function() {
+          return {
+            darkMode: appearanceQuery.matches,
+            background: themeToken('--theme-diagram-surface', '#ffffff'),
+            fontFamily: themeToken('--theme-font-family', 'ui-sans-serif, system-ui, sans-serif'),
+            fontSize: '14px',
+            primaryColor: themeToken('--theme-diagram-node-surface', '#f1f5f9'),
+            primaryTextColor: themeToken('--theme-diagram-text', '#243147'),
+            primaryBorderColor: themeToken('--theme-diagram-node-border', '#2563eb'),
+            secondaryColor: themeToken('--theme-quote-surface', '#f1f5f9'),
+            tertiaryColor: themeToken('--theme-table-surface', '#ffffff'),
+            lineColor: themeToken('--theme-diagram-line', '#64748b'),
+            mainBkg: themeToken('--theme-diagram-node-surface', '#f1f5f9'),
+            nodeBorder: themeToken('--theme-diagram-node-border', '#2563eb'),
+            clusterBkg: themeToken('--theme-table-surface', '#ffffff'),
+            clusterBorder: themeToken('--theme-border', '#cbd5e1'),
+            defaultLinkColor: themeToken('--theme-link', '#095fba'),
+            titleColor: themeToken('--theme-text', '#243147'),
+            edgeLabelBackground: themeToken('--theme-diagram-label-surface', '#ffffff'),
+            nodeTextColor: themeToken('--theme-diagram-text', '#243147'),
+            useGradient: false,
+            radius: 8,
+            strokeWidth: 2
+          };
+        };
+
+        const mermaidConfig = function(startOnLoad) {
+          return {
+            startOnLoad: startOnLoad,
+            securityLevel: 'loose',
+            theme: 'base',
+            themeVariables: mermaidThemeVariables(),
+            themeCSS: ${JSON.stringify(MERMAID_THEME_CSS)},
+            look: 'neo',
+            flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'rounded' },
+            sequence: { useMaxWidth: true },
+            gantt: { useMaxWidth: true },
+            er: { useMaxWidth: true },
+            pie: { useMaxWidth: true }
+          };
+        };
+
         // 将 <pre><code class="language-mermaid"> 转换为 <div class="mermaid">
         const convertMermaidCodeBlocks = function() {
           const codeBlocks = document.querySelectorAll('pre code.language-mermaid');
@@ -310,20 +326,41 @@ async function renderMarkdown(content, theme) {
         // 首先转换代码块
         convertMermaidCodeBlocks();
 
-        // 配置 Mermaid - 使用自定义 base 主题
-        mermaid.initialize({
-          startOnLoad: true,
-          securityLevel: 'loose',
-          theme: 'base',
-          themeVariables: isDarkMode ? ${JSON.stringify(MERMAID_DARK_THEME)} : ${JSON.stringify(MERMAID_LIGHT_THEME)},
-          themeCSS: ${JSON.stringify(MERMAID_THEME_CSS)},
-          look: 'neo',
-          flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'rounded' },
-          sequence: { useMaxWidth: true },
-          gantt: { useMaxWidth: true },
-          er: { useMaxWidth: true },
-          pie: { useMaxWidth: true }
+        document.querySelectorAll('.mermaid').forEach(function(el) {
+          if (!el.dataset.mermaidSource) {
+            el.dataset.mermaidSource = el.textContent;
+          }
         });
+
+        mermaid.initialize(mermaidConfig(true));
+
+        const rerenderForAppearance = function() {
+          const nodes = Array.from(document.querySelectorAll('.mermaid'));
+
+          nodes.forEach(function(el) {
+            if (el.dataset.mermaidSource) {
+              el.removeAttribute('data-processed');
+              el.textContent = el.dataset.mermaidSource;
+              el.classList.remove('mermaid-error');
+            }
+          });
+
+          mermaid.initialize(mermaidConfig(false));
+
+          if (typeof mermaid.run === 'function') {
+            Promise.resolve(mermaid.run({ nodes: nodes })).catch(function(error) {
+              console.error('Failed to rerender Mermaid after appearance change:', error);
+            });
+          } else if (typeof mermaid.init === 'function') {
+            nodes.forEach(function(el) { mermaid.init(undefined, el); });
+          }
+        };
+
+        if (typeof appearanceQuery.addEventListener === 'function') {
+          appearanceQuery.addEventListener('change', rerenderForAppearance);
+        } else if (typeof appearanceQuery.addListener === 'function') {
+          appearanceQuery.addListener(rerenderForAppearance);
+        }
         
         // 定时检查是否有未渲染的 Mermaid 元素
         setTimeout(function checkMermaidElements() {
@@ -402,9 +439,6 @@ async function renderMarkdown(content, theme) {
 
   const mermaidAssets = usesMermaid ? `${mermaidStyles}
       ${mermaidScript}` : '';
-  const highlightStylesheet = usesCodeHighlight
-    ? `<link rel="stylesheet" href="${HIGHLIGHT_CSS_CDN}">`
-    : '';
   const highlightScript = usesCodeHighlight
     ? `
       <script src="${HIGHLIGHT_JS_CDN}"></script>
@@ -460,7 +494,6 @@ async function renderMarkdown(content, theme) {
       
       <link rel="stylesheet" href="${MARKDOWN_THEME_BASELINE_HREF}">
       <link rel="stylesheet" href="${themeCss}">
-      ${highlightStylesheet}
       <style>
         :root {
           --theme-canvas: ${resolvedTheme.appearances.light.canvas};
@@ -780,7 +813,7 @@ ${escapedMermaidCode}
             startOnLoad: true,
             securityLevel: 'loose',
             theme: 'base',
-            themeVariables: isDark ? ${JSON.stringify(MERMAID_DARK_THEME)} : ${JSON.stringify(MERMAID_LIGHT_THEME)},
+            themeVariables: isDark ? ${JSON.stringify(STANDALONE_MERMAID_DARK_THEME)} : ${JSON.stringify(STANDALONE_MERMAID_LIGHT_THEME)},
             themeCSS: ${JSON.stringify(MERMAID_THEME_CSS)},
             look: 'neo',
             flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'rounded' },
@@ -961,10 +994,6 @@ async function renderContent(content, contentType, theme) {
   }
 }
 
-function resolveTheme(theme) {
-  return resolveMarkdownThemeId(theme);
-}
-
 /**
  * 预处理Markdown内容
  * @param {string} content - Markdown内容
@@ -1003,7 +1032,5 @@ module.exports = {
   renderMarkdown,
   renderSvg,
   renderMermaid,
-  escapeHtml,
-  resolveTheme,
-  MARKDOWN_THEMES
+  escapeHtml
 };

--- a/utils/contentRenderer.js
+++ b/utils/contentRenderer.js
@@ -5,14 +5,16 @@
 
 const { marked } = require('marked');
 const { CODE_TYPES } = require('./codeDetector');
+const {
+  MARKDOWN_THEME_BASELINE_HREF,
+  MARKDOWN_THEME_CATALOG,
+  resolveMarkdownTheme,
+  resolveMarkdownThemeId
+} = require('./markdownThemeCatalog');
 
-const MARKDOWN_THEMES = {
-  bytedance: '/css/markdown-bytedance.css',
-  github: '/css/markdown-github.css',
-  apple: '/css/markdown-apple.css',
-  notion: '/css/markdown-notion.css',
-  claude: '/css/markdown-claude.css'
-};
+const MARKDOWN_THEMES = Object.freeze(Object.fromEntries(
+  MARKDOWN_THEME_CATALOG.map(({ id, signatureHref }) => [id, signatureHref])
+));
 
 const MERMAID_LIGHT_THEME = {
   darkMode: false,
@@ -79,7 +81,6 @@ const MERMAID_CDN = 'https://cdn.jsdelivr.net/npm/mermaid@11.6.0/dist/mermaid.mi
 const HIGHLIGHT_CSS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/atom-one-dark.min.css';
 const HIGHLIGHT_JS_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js';
 
-const THEME_KEYS = Object.keys(MARKDOWN_THEMES);
 const MERMAID_PATTERNS = [
   /^(graph|flowchart)\s+(TB|TD|BT|RL|LR)\b/m,
   /^sequenceDiagram\b/m,
@@ -221,8 +222,8 @@ function renderHtml(content) {
  * @returns {string} - u6e32u67d3u540eu7684HTML
  */
 async function renderMarkdown(content, theme) {
-  const resolvedTheme = resolveTheme(theme);
-  const themeCss = MARKDOWN_THEMES[resolvedTheme] || MARKDOWN_THEMES.bytedance;
+  const resolvedTheme = resolveMarkdownTheme(theme);
+  const themeCss = resolvedTheme.signatureHref;
   // 预处理内容，处理独立的 Mermaid 代码
   const processedContent = await preprocessMarkdown(content);
   
@@ -438,7 +439,7 @@ async function renderMarkdown(content, theme) {
   // 返回带有字节跳动风格的HTML
   return `
     <!DOCTYPE html>
-    <html lang="zh-CN">
+    <html lang="zh-CN" data-markdown-theme="${resolvedTheme.id}">
     <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -449,24 +450,24 @@ async function renderMarkdown(content, theme) {
       <link rel="apple-touch-icon" href="/icon/web/apple-touch-icon.png">
       <link rel="icon" type="image/png" sizes="192x192" href="/icon/web/icon-192.png">
       <link rel="icon" type="image/png" sizes="512x512" href="/icon/web/icon-512.png">
-      <meta name="theme-color" content="#6366f1">
+      <meta name="theme-color" content="${resolvedTheme.appearances.light.themeColor}" media="(prefers-color-scheme: light)">
+      <meta name="theme-color" content="${resolvedTheme.appearances.dark.themeColor}" media="(prefers-color-scheme: dark)">
       
       <!-- iOS 特殊设置 -->
       <meta name="apple-mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
       <meta name="apple-mobile-web-app-title" content="QuickShare">
       
+      <link rel="stylesheet" href="${MARKDOWN_THEME_BASELINE_HREF}">
       <link rel="stylesheet" href="${themeCss}">
       ${highlightStylesheet}
       <style>
-        body {
-          margin: 0;
-          padding: 0;
-          background-color: #f5f5f7;
+        :root {
+          --theme-canvas: ${resolvedTheme.appearances.light.canvas};
         }
         @media (prefers-color-scheme: dark) {
-          body {
-            background-color: #1a1a1a;
+          :root {
+            --theme-canvas: ${resolvedTheme.appearances.dark.canvas};
           }
         }
         ${embeddedStyles}
@@ -961,10 +962,7 @@ async function renderContent(content, contentType, theme) {
 }
 
 function resolveTheme(theme) {
-  if (!theme || theme === 'random') {
-    return 'bytedance';
-  }
-  return MARKDOWN_THEMES[theme] ? theme : 'bytedance';
+  return resolveMarkdownThemeId(theme);
 }
 
 /**

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -28,7 +28,8 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'tesla', label: 'Tesla 黑白', light: '#ffffff', dark: '#050505' }),
   catalogEntry({ id: 'airbnb', label: 'Airbnb 暖居', light: '#fff8f2', dark: '#211a18' }),
   catalogEntry({ id: 'bugatti', label: 'Bugatti 蓝曜', light: '#f4f8fc', dark: '#0b0e12' }),
-  catalogEntry({ id: 'linear', label: 'Linear 精密', light: '#f7f8fb', dark: '#17191f' })
+  catalogEntry({ id: 'linear', label: 'Linear 精密', light: '#f7f8fb', dark: '#17191f' }),
+  catalogEntry({ id: 'playstation', label: 'PlayStation 蓝境', light: '#f1f7ff', dark: '#071629' })
 ]);
 
 const CATALOG_BY_ID = new Map(MARKDOWN_THEME_CATALOG.map(theme => [theme.id, theme]));

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -34,7 +34,9 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
 
 const CATALOG_BY_ID = new Map(MARKDOWN_THEME_CATALOG.map(theme => [theme.id, theme]));
 const MARKDOWN_THEME_OPTIONS = Object.freeze(
-  MARKDOWN_THEME_CATALOG.map(({ id, label }) => Object.freeze({ id, label }))
+  MARKDOWN_THEME_CATALOG.map(({ id, label, signatureHref }) => (
+    Object.freeze({ id, label, signatureHref })
+  ))
 );
 
 function resolveMarkdownThemeId(value) {

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -25,7 +25,9 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf7f2', dark: '#211e1a' }),
   catalogEntry({ id: 'raycast', label: 'Raycast 专注', light: '#f4f1f6', dark: '#151119' }),
   catalogEntry({ id: 'google', label: 'Google Material', light: '#f8fafd', dark: '#111318' }),
+  catalogEntry({ id: 'tesla', label: 'Tesla 黑白', light: '#ffffff', dark: '#050505' }),
   catalogEntry({ id: 'airbnb', label: 'Airbnb 暖居', light: '#fff8f2', dark: '#211a18' }),
+  catalogEntry({ id: 'bugatti', label: 'Bugatti 蓝曜', light: '#f4f8fc', dark: '#0b0e12' }),
   catalogEntry({ id: 'linear', label: 'Linear 精密', light: '#f7f8fb', dark: '#17191f' })
 ]);
 

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -1,0 +1,54 @@
+const DEFAULT_MARKDOWN_THEME_ID = 'bytedance';
+const MARKDOWN_THEME_BASELINE_HREF = '/css/markdown-theme-baseline.css';
+
+function appearance(canvas, themeColor = canvas) {
+  return Object.freeze({ canvas, themeColor });
+}
+
+function catalogEntry({ id, label, light, dark }) {
+  return Object.freeze({
+    id,
+    label,
+    signatureHref: `/css/markdown-${id}.css`,
+    appearances: Object.freeze({
+      light: appearance(light),
+      dark: appearance(dark)
+    })
+  });
+}
+
+const MARKDOWN_THEME_CATALOG = Object.freeze([
+  catalogEntry({ id: 'bytedance', label: 'ByteDance 蓝绿', light: '#f5f7fa', dark: '#111827' }),
+  catalogEntry({ id: 'github', label: 'GitHub 经典', light: '#ffffff', dark: '#ffffff' }),
+  catalogEntry({ id: 'apple', label: 'Apple 极简', light: '#ffffff', dark: '#ffffff' }),
+  catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#ffffff', dark: '#ffffff' }),
+  catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf9f5', dark: '#faf9f5' })
+]);
+
+const CATALOG_BY_ID = new Map(MARKDOWN_THEME_CATALOG.map(theme => [theme.id, theme]));
+const MARKDOWN_THEME_OPTIONS = Object.freeze(
+  MARKDOWN_THEME_CATALOG.map(({ id, label }) => Object.freeze({ id, label }))
+);
+
+function resolveMarkdownThemeId(value) {
+  return typeof value === 'string' && CATALOG_BY_ID.has(value)
+    ? value
+    : DEFAULT_MARKDOWN_THEME_ID;
+}
+
+function resolveMarkdownTheme(value) {
+  return CATALOG_BY_ID.get(resolveMarkdownThemeId(value));
+}
+
+function getMarkdownThemeOptions() {
+  return MARKDOWN_THEME_OPTIONS;
+}
+
+module.exports = {
+  DEFAULT_MARKDOWN_THEME_ID,
+  MARKDOWN_THEME_BASELINE_HREF,
+  MARKDOWN_THEME_CATALOG,
+  getMarkdownThemeOptions,
+  resolveMarkdownTheme,
+  resolveMarkdownThemeId
+};

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -22,7 +22,9 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'github', label: 'GitHub 经典', light: '#ffffff', dark: '#0d1117' }),
   catalogEntry({ id: 'apple', label: 'Apple 极简', light: '#ffffff', dark: '#000000' }),
   catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#fbfbfa', dark: '#191919' }),
-  catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf7f2', dark: '#211e1a' })
+  catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf7f2', dark: '#211e1a' }),
+  catalogEntry({ id: 'raycast', label: 'Raycast 专注', light: '#f4f1f6', dark: '#151119' }),
+  catalogEntry({ id: 'linear', label: 'Linear 精密', light: '#f7f8fb', dark: '#17191f' })
 ]);
 
 const CATALOG_BY_ID = new Map(MARKDOWN_THEME_CATALOG.map(theme => [theme.id, theme]));

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -19,8 +19,8 @@ function catalogEntry({ id, label, light, dark }) {
 
 const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'bytedance', label: 'ByteDance 蓝绿', light: '#f5f7fa', dark: '#111827' }),
-  catalogEntry({ id: 'github', label: 'GitHub 经典', light: '#ffffff', dark: '#ffffff' }),
-  catalogEntry({ id: 'apple', label: 'Apple 极简', light: '#ffffff', dark: '#ffffff' }),
+  catalogEntry({ id: 'github', label: 'GitHub 经典', light: '#ffffff', dark: '#0d1117' }),
+  catalogEntry({ id: 'apple', label: 'Apple 极简', light: '#ffffff', dark: '#000000' }),
   catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#ffffff', dark: '#ffffff' }),
   catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf9f5', dark: '#faf9f5' })
 ]);

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -24,6 +24,8 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#fbfbfa', dark: '#191919' }),
   catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf7f2', dark: '#211e1a' }),
   catalogEntry({ id: 'raycast', label: 'Raycast 专注', light: '#f4f1f6', dark: '#151119' }),
+  catalogEntry({ id: 'google', label: 'Google Material', light: '#f8fafd', dark: '#111318' }),
+  catalogEntry({ id: 'airbnb', label: 'Airbnb 暖居', light: '#fff8f2', dark: '#211a18' }),
   catalogEntry({ id: 'linear', label: 'Linear 精密', light: '#f7f8fb', dark: '#17191f' })
 ]);
 

--- a/utils/markdownThemeCatalog.js
+++ b/utils/markdownThemeCatalog.js
@@ -21,8 +21,8 @@ const MARKDOWN_THEME_CATALOG = Object.freeze([
   catalogEntry({ id: 'bytedance', label: 'ByteDance 蓝绿', light: '#f5f7fa', dark: '#111827' }),
   catalogEntry({ id: 'github', label: 'GitHub 经典', light: '#ffffff', dark: '#0d1117' }),
   catalogEntry({ id: 'apple', label: 'Apple 极简', light: '#ffffff', dark: '#000000' }),
-  catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#ffffff', dark: '#ffffff' }),
-  catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf9f5', dark: '#faf9f5' })
+  catalogEntry({ id: 'notion', label: 'Notion 笔记', light: '#fbfbfa', dark: '#191919' }),
+  catalogEntry({ id: 'claude', label: 'Claude 暖调', light: '#faf7f2', dark: '#211e1a' })
 ]);
 
 const CATALOG_BY_ID = new Map(MARKDOWN_THEME_CATALOG.map(theme => [theme.id, theme]));

--- a/views/admin-page-detail.ejs
+++ b/views/admin-page-detail.ejs
@@ -149,14 +149,15 @@
             <% } %>
           </p>
         </div>
-        <div class="admin-edit-field" id="theme-field" <%= sharedPage.codeType !== 'markdown' ? 'hidden' : '' %>>
-          <label for="edit-theme">Markdown 主题</label>
-          <select id="edit-theme" name="markdownTheme">
-            <% markdownThemeOptions.forEach((theme) => { %>
-              <option value="<%= theme.id %>" <%= sharedPage.markdownTheme === theme.id ? 'selected' : '' %>><%= theme.label %></option>
-            <% }); %>
-          </select>
-        </div>
+        <% if (sharedPage.codeType === 'markdown') { %>
+          <%- include('partials/theme-sampler', {
+            containerId: 'theme-field',
+            containerClass: 'admin-edit-field',
+            selectId: 'edit-theme',
+            selectedThemeId: sharedPage.markdownTheme,
+            markdownThemeOptions
+          }) %>
+        <% } %>
       </div>
       <div class="admin-edit-actions">
         <button type="button" class="cyber-btn cyber-btn-secondary" id="edit-cancel">取消</button>
@@ -197,5 +198,6 @@
 <script src="/js/admin.js"></script>
 <script src="/js/admin-favorite.js"></script>
 <script src="/js/admin-time.js"></script>
+<script src="/js/theme-sampler.js"></script>
 <script src="/js/admin-detail.js"></script>
 <%- include('partials/footer', { page }) %>

--- a/views/admin-page-detail.ejs
+++ b/views/admin-page-detail.ejs
@@ -152,11 +152,9 @@
         <div class="admin-edit-field" id="theme-field" <%= sharedPage.codeType !== 'markdown' ? 'hidden' : '' %>>
           <label for="edit-theme">Markdown 主题</label>
           <select id="edit-theme" name="markdownTheme">
-            <option value="bytedance" <%= !sharedPage.markdownTheme || sharedPage.markdownTheme === 'bytedance' ? 'selected' : '' %>>ByteDance</option>
-            <option value="github" <%= sharedPage.markdownTheme === 'github' ? 'selected' : '' %>>GitHub</option>
-            <option value="apple" <%= sharedPage.markdownTheme === 'apple' ? 'selected' : '' %>>Apple</option>
-            <option value="notion" <%= sharedPage.markdownTheme === 'notion' ? 'selected' : '' %>>Notion</option>
-            <option value="claude" <%= sharedPage.markdownTheme === 'claude' ? 'selected' : '' %>>Claude</option>
+            <% markdownThemeOptions.forEach((theme) => { %>
+              <option value="<%= theme.id %>" <%= sharedPage.markdownTheme === theme.id ? 'selected' : '' %>><%= theme.label %></option>
+            <% }); %>
           </select>
         </div>
       </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,17 +37,13 @@
           <p id="file-name" class="file-name-text"></p>
         </div>
 
-        <div id="markdown-theme-selector" class="markdown-theme-selector hidden">
-          <div class="theme-selector-header">
-            <i class="fas fa-palette" aria-hidden="true"></i>
-            <span class="theme-label">Markdown Theme</span>
-          </div>
-          <select id="markdown-theme" class="theme-select">
-            <% markdownThemeOptions.forEach((theme) => { %>
-              <option value="<%= theme.id %>" <%= theme.id === 'bytedance' ? 'selected' : '' %>><%= theme.label %></option>
-            <% }); %>
-          </select>
-        </div>
+        <%- include('partials/theme-sampler', {
+          containerId: 'markdown-theme-selector',
+          containerClass: 'markdown-theme-selector hidden',
+          selectId: 'markdown-theme',
+          selectedThemeId: 'bytedance',
+          markdownThemeOptions
+        }) %>
 
         <section id="publish-settings" class="publish-settings" aria-labelledby="publish-settings-title">
           <h2 id="publish-settings-title" class="publish-settings-title">发布设置</h2>
@@ -224,4 +220,5 @@
   </footer>
 </div>
 
+<script src="/js/theme-sampler.js"></script>
 <%- include('partials/footer', { page }) %>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -43,11 +43,9 @@
             <span class="theme-label">Markdown Theme</span>
           </div>
           <select id="markdown-theme" class="theme-select">
-            <option value="bytedance" selected>ByteDance 蓝绿</option>
-            <option value="github">GitHub 经典</option>
-            <option value="apple">Apple 极简</option>
-            <option value="notion">Notion 笔记</option>
-            <option value="claude">Claude 暖调</option>
+            <% markdownThemeOptions.forEach((theme) => { %>
+              <option value="<%= theme.id %>" <%= theme.id === 'bytedance' ? 'selected' : '' %>><%= theme.label %></option>
+            <% }); %>
           </select>
         </div>
 

--- a/views/partials/theme-sampler.ejs
+++ b/views/partials/theme-sampler.ejs
@@ -1,0 +1,96 @@
+<%
+  const selectedTheme = markdownThemeOptions.find(theme => theme.id === selectedThemeId)
+    || markdownThemeOptions[0];
+  const samplerLabel = `${selectedTheme.label}主题样例`;
+%>
+<div
+  id="<%= containerId %>"
+  class="<%= containerClass %> theme-sampler-settings"
+  data-theme-sampler
+  data-select-id="<%= selectId %>"
+  role="region"
+  aria-label="<%= samplerLabel %>"
+>
+  <div class="theme-sampler-control">
+    <label for="<%= selectId %>">Markdown 主题</label>
+    <select
+      id="<%= selectId %>"
+      class="theme-select"
+      name="markdownTheme"
+      aria-controls="<%= selectId %>-sampler"
+    >
+      <% markdownThemeOptions.forEach((theme) => { %>
+        <option
+          value="<%= theme.id %>"
+          data-theme-label="<%= theme.label %>"
+          data-signature-href="<%= theme.signatureHref %>"
+          <%= theme.id === selectedTheme.id ? 'selected' : '' %>
+        ><%= theme.label %></option>
+      <% }); %>
+    </select>
+    <span class="field-hint">固定内容只用于比较视觉风格</span>
+  </div>
+
+  <div class="theme-sampler-preview">
+    <iframe
+      id="<%= selectId %>-sampler"
+      class="theme-sampler-frame"
+      data-theme-sampler-frame
+      title="<%= samplerLabel %>"
+      tabindex="-1"
+      sandbox=""
+      referrerpolicy="no-referrer"
+    ></iframe>
+
+    <template data-theme-sampler-template>
+      <article class="markdown-body theme-sampler-body">
+        <header class="theme-sampler-intro">
+          <h1 data-sample-role="heading">创作样例</h1>
+          <p data-sample-role="body">用同一段固定内容，快速比较每种主题的阅读气质。</p>
+          <p data-sample-role="emphasis"><strong>重点文字</strong> 与 <em>强调语气</em> 保持清晰层级。</p>
+        </header>
+
+        <div class="theme-sampler-grid">
+          <section>
+            <h2>内容结构</h2>
+            <p><a data-sample-role="link">主题链接样式</a></p>
+            <ul data-sample-role="list">
+              <li>紧凑的列表项目</li>
+              <li data-sample-role="task"><input type="checkbox" checked disabled tabindex="-1"> 已完成任务</li>
+            </ul>
+            <blockquote data-sample-role="quotation">让重要说明在长文中容易辨认。</blockquote>
+          </section>
+
+          <section>
+            <h2>技术内容</h2>
+            <p data-sample-role="inline-code">行内命令 <code>npm test</code></p>
+            <pre data-sample-role="fenced-code"><code>const ready = true;</code></pre>
+            <p data-sample-role="keyboard">按 <kbd>⌘</kbd> + <kbd>Enter</kbd> 继续</p>
+          </section>
+        </div>
+
+        <div class="theme-sampler-assets">
+          <table data-sample-role="table">
+            <thead><tr><th>主题</th><th>状态</th></tr></thead>
+            <tbody><tr><td>当前预设</td><td>可读</td></tr></tbody>
+          </table>
+
+          <figure data-sample-role="image" class="theme-sampler-image">
+            <svg viewBox="0 0 320 72" role="img" aria-label="响应式图片处理示例">
+              <rect x="1" y="1" width="318" height="70" rx="10" fill="var(--theme-soft-surface, var(--theme-table-surface))" stroke="var(--theme-border)" />
+              <circle cx="54" cy="36" r="16" fill="var(--theme-accent)" opacity="0.72" />
+              <path d="M88 48 122 22l31 22 34-29 48 33Z" fill="var(--theme-secondary, var(--theme-accent))" opacity="0.55" />
+            </svg>
+            <figcaption>图片会在阅读栏内自适应</figcaption>
+          </figure>
+        </div>
+
+        <hr data-sample-role="divider">
+
+        <div data-sample-role="diagram" class="theme-sampler-diagram" role="img" aria-label="静态流程图表面示例">
+          <span>构思</span><i aria-hidden="true"></i><span>发布</span>
+        </div>
+      </article>
+    </template>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Implements the Markdown Theme Catalog program tracked by #10.

Current completed slice:

- #11 server-owned Catalog and trusted projection
- shared Theme Reading Baseline
- ByteDance light/dark signature and deterministic fallback
- renderer/HTTP/compatibility contracts

Additional child tickets remain blocked or in progress. This PR stays draft until #12–#19 and release verification are complete.

## Verification

- focused Catalog/renderer/HTTP tests: 18/18
- complete Node suite: 189/189
- real-browser ByteDance light/dark at 375/768/1440
- signature failure retains readable, contained content
- PostgreSQL integration runs in this PR's CI

Refs #10
