### PR TITLE
fix: refresh social card image cache key

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 require('dotenv').config();
 
 const express = require('express');
+const { createHash, randomBytes, timingSafeEqual } = require('node:crypto');
+const fs = require('node:fs');
 const path = require('path');
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
@@ -46,6 +48,11 @@ const PUBLIC_DIR = path.join(__dirname, 'public');
 const FAVICON_PATH = path.join(PUBLIC_DIR, 'icon/web/favicon.ico');
 const STATIC_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
 const STATIC_CACHE_CONTROL = 'public, max-age=300, must-revalidate';
+const SOCIAL_IMAGE_PATH = '/icon/web/icon-512.png';
+const SOCIAL_IMAGE_VERSION = createHash('sha256')
+  .update(fs.readFileSync(path.join(PUBLIC_DIR, SOCIAL_IMAGE_PATH)))
+  .digest('hex')
+  .slice(0, 12);
 const EMBEDDABLE_UI_CSP = [
   "default-src 'self'",
   "base-uri 'none'",
@@ -60,7 +67,6 @@ const EMBEDDABLE_UI_CSP = [
   "frame-src 'self'"
 ].join('; ');
 const TRUSTED_UI_CSP = `${EMBEDDABLE_UI_CSP}; frame-ancestors 'none'`;
-const { randomBytes, timingSafeEqual } = require('crypto');
 let nextViewRequestIsColdStart = true;
 
 const app = express();
@@ -117,6 +123,10 @@ app.use(express.static(PUBLIC_DIR, {
   etag: true,
   setHeaders: setStaticCacheHeaders
 }));
+app.use((req, res, next) => {
+  res.locals.socialImageUrl = socialImageUrl(req);
+  return next();
+});
 
 function setPrivateNoStore(res) {
   res.set('Cache-Control', 'private, no-store');
@@ -771,6 +781,7 @@ function renderSandboxedDocument(renderedContent, contentType, {
   title,
   description,
   pageUrl,
+  socialImageUrl,
   viewEventUrl
 } = {}) {
   const escapedContent = escapeHtml(renderedContent);
@@ -790,7 +801,11 @@ function renderSandboxedDocument(renderedContent, contentType, {
       <meta property="og:description" content="${ogDescription}">
       <meta property="og:type" content="article">
       ${ogUrl ? `<meta property="og:url" content="${ogUrl}">` : ''}
-      <meta property="og:image" content="/icon/web/icon-512.png">
+      <meta property="og:image" content="${escapeHtml(socialImageUrl)}">
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="512">
+      <meta property="og:image:height" content="512">
+      <meta property="og:image:alt" content="QuickShare Site Identity Icon">
       <meta name="twitter:card" content="summary">
       <meta name="twitter:title" content="${pageTitle}">
       <meta name="twitter:description" content="${ogDescription}">
@@ -872,8 +887,16 @@ function buildAdminPagesUrl(filters, overrides = {}) {
 }
 
 function publicPageUrl(req, id) {
+  return `${publicOrigin(req)}/view/${encodeURIComponent(id)}`;
+}
+
+function publicOrigin(req) {
   const base = config.shareBaseUrl || config.baseUrl || `${req.protocol}://${req.get('host')}`;
-  return `${base.replace(/\/+$/, '')}/view/${encodeURIComponent(id)}`;
+  return base.replace(/\/+$/, '');
+}
+
+function socialImageUrl(req) {
+  return `${publicOrigin(req)}${SOCIAL_IMAGE_PATH}?v=${SOCIAL_IMAGE_VERSION}`;
 }
 
 function enrichAdminStats(stats) {
@@ -1011,7 +1034,8 @@ app.get('/', privateNoStore, requireHomepageAccess, (req, res) => {
     title: 'QuickShare | 粘贴代码，一键分享',
     page: 'home-page',
     csrfToken: req.homepageAccessMode === 'locked' ? createCsrfToken(sessionToken) : '',
-    markdownThemeOptions: getMarkdownThemeOptions()
+    markdownThemeOptions: getMarkdownThemeOptions(),
+    socialImageUrl: socialImageUrl(req)
   });
 });
 
@@ -1662,7 +1686,8 @@ app.post('/api/pages/preview', privateNoStore, requireBrowserPublishAccess, pars
       codeType: prepared.contentType,
       document: renderSandboxedDocument(prepared.renderedContent, prepared.contentType, {
         title: title ? String(title).trim() : null,
-        description: description ? String(description).trim() : null
+        description: description ? String(description).trim() : null,
+        socialImageUrl: socialImageUrl(req)
       })
     });
   } catch (error) {
@@ -1982,6 +2007,7 @@ app.get('/view/:id', async (req, res) => {
       title: page.title,
       description: page.description,
       pageUrl,
+      socialImageUrl: socialImageUrl(req),
       viewEventUrl
     }));
   } catch (error) {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,27 @@
 # QuickShare Optimization Implementation Plan
 
+## Enterprise WeChat social-card OG image cache fix (2026-07-23)
+
+- [x] Confirm the clean isolated worktree is based on current `origin/main`, and verify the local 512 px social image hash.
+- [x] RED: add independent PNG hashing plus homepage and public-Share HTTP assertions for one absolute, content-versioned social image URL and complete image metadata.
+- [x] GREEN: compute the short SHA-256 at startup, centralize origin selection and social image URL construction, and pass the result to both rendering paths.
+- [x] Run the focused resource-policy test, complete Node suite, JavaScript syntax checks, and `git diff --check`.
+- [x] Run the required code review, remediate blocking findings, and record the review evidence below.
+- [ ] Commit, push, deploy the reviewed revision to Production, and verify the exact deployment is `READY`.
+- [ ] Verify live homepage and real public-Share HTML use the same absolute versioned OG image URL; verify versioned and unversioned image bytes both have the expected full SHA-256.
+- [ ] Hand off Enterprise WeChat HITL: resend the link to create a new card; do not claim old message snapshots refresh automatically.
+
+Verify:
+
+1. RED loop -> `NODE_ENV=test VERCEL_ENV= DATABASE_URL= POSTGRES_URL= node --test test/resource-policy.test.js` fails only because current OG image metadata is relative or unversioned/incomplete.
+2. Local image -> `public/icon/web/icon-512.png` hashes to `60b7b9542bb42100e4a090b0da98a2d7724ced25b6026bee20f14112bb51167a`; emitted query version is `60b7b9542bb4`.
+3. URL origin -> `shareBaseUrl` wins over `baseUrl`, which wins over the request origin; both homepage and public Share consume the same centralized result.
+4. Scope -> favicon, functional icons, identity filenames, Manifest behavior, and rendered page visuals remain unchanged.
+5. Production -> deployment is `READY`; homepage and `https://quickshare.namooca.com/view/PiTpTWr-sDUu` expose identical absolute versioned `og:image` plus PNG type, 512x512 dimensions, and alt metadata.
+6. Asset bytes -> production image responses with and without the version query both match the complete expected SHA-256.
+
+Review: RED reproduced the exact relative/unversioned OG URL failure. The focused resource-policy suite passes 7/7 and the complete Node suite passes 242/242; changed JavaScript syntax and `git diff --check` pass. Standards and Spec reviews each returned 0 findings. Commit, push, Production deployment, live HTML/hash evidence, and Enterprise WeChat HITL remain pending.
+
 ## Markdown Theme Sampler layout implementation (2026-07-23)
 
 - [x] RED/GREEN: render the confirmed five-part fixed Theme Sampler without full-document test elements.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,9 +7,9 @@
 - [x] GREEN: compute the short SHA-256 at startup, centralize origin selection and social image URL construction, and pass the result to both rendering paths.
 - [x] Run the focused resource-policy test, complete Node suite, JavaScript syntax checks, and `git diff --check`.
 - [x] Run the required code review, remediate blocking findings, and record the review evidence below.
-- [ ] Commit, push, deploy the reviewed revision to Production, and verify the exact deployment is `READY`.
-- [ ] Verify live homepage and real public-Share HTML use the same absolute versioned OG image URL; verify versioned and unversioned image bytes both have the expected full SHA-256.
-- [ ] Hand off Enterprise WeChat HITL: resend the link to create a new card; do not claim old message snapshots refresh automatically.
+- [x] Commit, push, deploy the reviewed revision to Production, and verify the exact deployment is `READY`.
+- [x] Verify live homepage and real public-Share HTML use the same absolute versioned OG image URL; verify versioned and unversioned image bytes both have the expected full SHA-256.
+- [x] Hand off Enterprise WeChat HITL: resend the link to create a new card; do not claim old message snapshots refresh automatically.
 
 Verify:
 
@@ -20,7 +20,7 @@ Verify:
 5. Production -> deployment is `READY`; homepage and `https://quickshare.namooca.com/view/PiTpTWr-sDUu` expose identical absolute versioned `og:image` plus PNG type, 512x512 dimensions, and alt metadata.
 6. Asset bytes -> production image responses with and without the version query both match the complete expected SHA-256.
 
-Review: RED reproduced the exact relative/unversioned OG URL failure. The focused resource-policy suite passes 7/7 and the complete Node suite passes 242/242; changed JavaScript syntax and `git diff --check` pass. Standards and Spec reviews each returned 0 findings. Commit, push, Production deployment, live HTML/hash evidence, and Enterprise WeChat HITL remain pending.
+Review: RED reproduced the exact relative/unversioned OG URL failure. The focused resource-policy suite passes 7/7 and the complete Node suite passes 242/242; changed JavaScript syntax and `git diff --check` pass. Standards and Spec reviews each returned 0 findings. Implementation commit `def15b9` is pushed. Production deployment `dpl_GRUZoCtXW3YfJR27zgYehbJ7W4AE` reached READY and was aliased to `quickshare.namooca.com`. Browser and Enterprise WeChat user agents both received the same complete OG image metadata on the homepage and real public Share. Versioned and unversioned image responses were both 48,799-byte PNG files with SHA-256 `60b7b9542bb42100e4a090b0da98a2d7724ced25b6026bee20f14112bb51167a`. Enterprise WeChat still requires a newly sent link for human verification; old message snapshots are not expected to refresh.
 
 ## Markdown Theme Sampler layout implementation (2026-07-23)
 

--- a/test/resource-policy.test.js
+++ b/test/resource-policy.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
@@ -119,6 +120,35 @@ function assertHasUmamiTracker(html) {
     /<script defer src="https:\/\/umami\.namooca\.com\/script\.js" data-website-id="c5b79d49-f1e7-46c1-87c7-b2965383c820"><\/script>/
   );
 }
+
+function assertSocialImageMetadata(html, expectedUrl) {
+  const imageUrls = Array.from(
+    html.matchAll(/<meta property="og:image" content="([^"]+)">/g),
+    (match) => match[1]
+  );
+
+  assert.deepEqual(imageUrls, [expectedUrl]);
+  assert.match(html, /<meta property="og:image:type" content="image\/png">/);
+  assert.match(html, /<meta property="og:image:width" content="512">/);
+  assert.match(html, /<meta property="og:image:height" content="512">/);
+  assert.match(html, /<meta property="og:image:alt" content="QuickShare Site Identity Icon">/);
+}
+
+test('homepage and public Share expose one absolute content-versioned social image', async () => {
+  const imageBytes = fs.readFileSync(path.join(__dirname, '../public/icon/web/icon-512.png'));
+  const imageHash = crypto.createHash('sha256').update(imageBytes).digest('hex');
+  const expectedUrl = `${baseUrl}/icon/web/icon-512.png?v=${imageHash.slice(0, 12)}`;
+  const [homepage, sharePage] = await Promise.all([
+    request('/', { headers: { Cookie: homeCookie } }),
+    request('/view/resource-public')
+  ]);
+
+  assert.equal(homepage.status, 200);
+  assert.equal(sharePage.status, 200);
+  assert.equal(imageHash, '60b7b9542bb42100e4a090b0da98a2d7724ced25b6026bee20f14112bb51167a');
+  assertSocialImageMetadata(homepage.text, expectedUrl);
+  assertSocialImageMetadata(sharePage.text, expectedUrl);
+});
 
 test('each trusted route loads only the scripts it uses', async () => {
   const [homepage, loginPage, passwordPage, errorPage, statsPage, auditPage, apiPage] = await Promise.all([

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -22,7 +22,11 @@
   <meta property="og:title" content="QuickShare | 粘贴代码，一键分享">
   <meta property="og:description" content="粘贴 HTML / Markdown / SVG / Mermaid 代码，一键生成分享链接">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="/icon/web/icon-512.png">
+  <meta property="og:image" content="<%= socialImageUrl %>">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="512">
+  <meta property="og:image:height" content="512">
+  <meta property="og:image:alt" content="QuickShare Site Identity Icon">
 
   <script defer src="https://umami.namooca.com/script.js" data-website-id="c5b79d49-f1e7-46c1-87c7-b2965383c820"></script>
 


### PR DESCRIPTION
## Summary
- derive the social preview image version from the deployed PNG bytes
- emit one absolute, versioned OG image URL on the homepage and public Shares
- add complete PNG metadata and an HTTP regression test

## Verification
- focused resource-policy tests: 7/7
- full Node suite: 242/242
- Standards review: 0 findings
- Spec review: 0 findings
- Production deployment: dpl_5BeGVoGd6fHGyvji3CoHUfg4dgkg READY
- live browser and WeCom-UA metadata plus versioned/unversioned image SHA-256 verified